### PR TITLE
build: reconfigure cmake project to use static library + create exe for each test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(OpenSSL REQUIRED)
 find_package(Boost CONFIG REQUIRED COMPONENTS system)
 find_package(nlohmann_json REQUIRED)
 find_package(GTest CONFIG REQUIRED)
+find_package(PkgConfig REQUIRED)
 
 include_directories(include)
 include_directories(third-party)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,20 +1,29 @@
-add_library(LoggingUtils OBJECT LoggingUtils.cpp)
-target_link_libraries(LoggingUtils PUBLIC easylogging)
-
-add_library(WebSocketSession OBJECT WebSocketSession.cpp)
-target_link_libraries(WebSocketSession
-        PUBLIC
-        Boost::system
-        OpenSSL::SSL
-        OpenSSL::Crypto
-        LoggingUtils
+# Collect all source files
+file(GLOB_RECURSE MACD_TRADING_BOT_SRCS 
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/indicators/*.cpp"
 )
 
-add_library(Utils OBJECT Utils.cpp)
+# Create the main static library
+add_library(macd-trading-bot STATIC ${MACD_TRADING_BOT_SRCS})
 
-add_library(AlpacaMarketFeed OBJECT AlpacaWSMarketFeed.cpp)
-target_link_libraries(AlpacaMarketFeed PUBLIC WebSocketSession nlohmann_json::nlohmann_json Utils)
+# Link all required dependencies
+target_link_libraries(macd-trading-bot 
+    PUBLIC
+    easylogging
+    Boost::system
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    nlohmann_json::nlohmann_json
+)
 
-file(GLOB INDICATORS_SRCS indicators/*.cpp)
-add_library(Indicators OBJECT ${INDICATORS_SRCS})
-target_include_directories(Indicators PUBLIC ${CMAKE_SOURCE_DIR}/include)
+# Set include directories
+target_include_directories(macd-trading-bot 
+    PUBLIC 
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/third-party
+)
+
+# Link TA-Lib for indicators
+pkg_check_modules(TALIB REQUIRED IMPORTED_TARGET ta-lib)
+target_link_libraries(macd-trading-bot PUBLIC PkgConfig::TALIB)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,3 @@ target_include_directories(macd-trading-bot
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/third-party
 )
-
-# Link TA-Lib for indicators
-pkg_check_modules(TALIB REQUIRED IMPORTED_TARGET ta-lib)
-target_link_libraries(macd-trading-bot PUBLIC PkgConfig::TALIB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,5 +35,9 @@ foreach(TEST_FILE ${TEST_FILES})
     gtest_discover_tests(${TEST_NAME})
 endforeach()
 
+# Add TA-Lib dependency only for TestIndicators (the only test that uses it)
+pkg_check_modules(TALIB REQUIRED IMPORTED_TARGET ta-lib)
+target_link_libraries(TestIndicators PUBLIC PkgConfig::TALIB)
+
 # Include GoogleTest for test discovery
 include(GoogleTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,30 +1,39 @@
-add_executable(unit_tests
-        TestWebSocketSession.cpp
-        TestAlpacaWSMarketFeed.cpp
-        TestBarAggregatorIntegration.cpp
-        TestBar.cpp
-        TestUtils.cpp
-        TestIndicators.cpp
-        TestIndicatorEngine.cpp
+# List of test files
+set(TEST_FILES
+    TestWebSocketSession.cpp
+    TestAlpacaWSMarketFeed.cpp
+    TestBarAggregatorIntegration.cpp
+    TestBar.cpp
+    TestUtils.cpp
+    TestIndicators.cpp
+    TestIndicatorEngine.cpp
 )
-target_link_libraries(unit_tests
+
+# Create a separate executable for each test file
+foreach(TEST_FILE ${TEST_FILES})
+    # Get the test name without extension
+    get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+    
+    # Create executable for this test
+    add_executable(${TEST_NAME} ${TEST_FILE})
+    
+    # Link against the main static library and GTest
+    target_link_libraries(${TEST_NAME}
         PUBLIC
-        easylogging
-        LoggingUtils
-        WebSocketSession
-        AlpacaMarketFeed
-        Utils
-        Indicators
+        macd-trading-bot
         GTest::gtest_main
-)
-
-pkg_check_modules(TALIB REQUIRED IMPORTED_TARGET ta-lib)
-target_link_libraries(unit_tests PUBLIC PkgConfig::TALIB)
-
-target_include_directories(unit_tests
+    )
+    
+    # Set include directories
+    target_include_directories(${TEST_NAME}
         PUBLIC
         ${CMAKE_SOURCE_DIR}/include
-)
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    
+    # Register the test with CTest
+    gtest_discover_tests(${TEST_NAME})
+endforeach()
 
+# Include GoogleTest for test discovery
 include(GoogleTest)
-gtest_discover_tests(unit_tests)


### PR DESCRIPTION
The CMake project was reconfigured to meet new build requirements.

*   In `src/CMakeLists.txt`, the project was refactored to build a single static library, `macd-trading-bot`.
    *   All `.cpp` files within `src/` and `src/indicators/` are now collected using `file(GLOB_RECURSE)` and compiled into this single library.
    *   Dependencies such as `easylogging`, `Boost::system`, `OpenSSL::SSL`, `OpenSSL::Crypto`, and `nlohmann_json::nlohmann_json` are linked directly to `macd-trading-bot`.
*   In `tests/CMakeLists.txt`, the test structure was updated to create a separate executable for each test suite.
    *   A `foreach` loop iterates through a `TEST_FILES` list, creating an `add_executable` for each test (e.g., `TestWebSocketSession`, `TestBar`).
    *   Each test executable is linked against the newly created `macd-trading-bot` static library and `GTest::gtest_main`.
    *   This change ensures that build errors in one test file do not prevent other unrelated tests from building and running.
*   The TA-Lib dependency was initially incorrectly added to the main library.
    *   It was identified that TA-Lib is only used by `TestIndicators.cpp` for validation purposes.
    *   The `pkg_check_modules(TALIB ...)` call was moved from the root `CMakeLists.txt` and the general test linking to be specifically linked only to the `TestIndicators` executable in `tests/CMakeLists.txt`.
    *   This ensures correct dependency scoping, linking TA-Lib only where it is actually needed.