### PR TITLE
refactor: use boost json instead of nlohmann json

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
           tar -xzf boost_1_88_0.tar.gz
           cd boost_1_88_0
           ./bootstrap.sh
-          sudo ./b2 install --prefix=/usr/local --with-system --with-url
+          sudo ./b2 install --prefix=/usr/local --with-system --with-url --with-json
 
       - name: Fix permissions before TA-Lib cache
         run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -33,6 +33,7 @@ jobs:
           path: |
             /usr/local/lib/libboost_system*
             /usr/local/lib/libboost_url*
+            /usr/local/lib/libboost_json*
             /usr/local/include/boost/
             /usr/local/lib/cmake/boost*
             /usr/local/lib/cmake/Boost*

--- a/alpaca_trade_client/CMakeLists.txt
+++ b/alpaca_trade_client/CMakeLists.txt
@@ -8,7 +8,7 @@ project(alpaca_trade_client
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(nlohmann_json CONFIG REQUIRED)
+find_package(Boost CONFIG REQUIRED COMPONENTS json)
 
 add_library(alpaca_trade_client STATIC
         src/alpaca_trade_client.cpp
@@ -16,7 +16,7 @@ add_library(alpaca_trade_client STATIC
 )
 target_include_directories(alpaca_trade_client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/async_rest_client/include)
 target_link_libraries(alpaca_trade_client PUBLIC
-        nlohmann_json::nlohmann_json
+        Boost::json
         async_rest_client
 )
 

--- a/alpaca_trade_client/include/alpaca_trade_client/account.hpp
+++ b/alpaca_trade_client/include/alpaca_trade_client/account.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <boost/json.hpp>
 #include <optional>
 #include <string>
 
@@ -69,8 +69,8 @@ struct trade_account
     std::optional<bool>        shorting_enabled{};
 };
 
-void to_json(nlohmann::json& j, const account_status& status);
-void from_json(const nlohmann::json& j, account_status& status);
+void           tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const account_status& status);
+account_status tag_invoke(boost::json::value_to_tag<account_status>, const boost::json::value& jv);
 
-void from_json(const nlohmann::json& j, trade_account& account);
-void to_json(nlohmann::json& j, const trade_account& account);
+void          tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const trade_account& account);
+trade_account tag_invoke(boost::json::value_to_tag<trade_account>, const boost::json::value& jv);

--- a/alpaca_trade_client/include/alpaca_trade_client/alpaca_trade_client.hpp
+++ b/alpaca_trade_client/include/alpaca_trade_client/alpaca_trade_client.hpp
@@ -9,12 +9,13 @@
 #include "position.hpp"
 
 #include <boost/beast/http.hpp>
+#include <boost/json.hpp>
 #include <expected>
 #include <memory>
-#include <nlohmann/json.hpp>
 #include <vector>
 
-namespace net = boost::asio;
+namespace net  = boost::asio;
+namespace json = boost::json;
 
 class alpaca_api_error
 {

--- a/alpaca_trade_client/include/alpaca_trade_client/enum_serialization.hpp
+++ b/alpaca_trade_client/include/alpaca_trade_client/enum_serialization.hpp
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <boost/json.hpp>
+#include <stdexcept>
+#include <string_view>
+
+#include "account.hpp"
+#include "orders.hpp"
+#include "position.hpp"
+
+namespace json = boost::json;
+
+template<typename EnumType>
+struct enum_mapping
+{
+    static constexpr std::array<std::pair<EnumType, std::string_view>, 0> mappings{};
+};
+
+template<>
+struct enum_mapping<account_status>
+{
+    static constexpr std::array<std::pair<account_status, std::string_view>, 21> mappings{
+        {{account_status::ACCOUNT_CLOSED, "ACCOUNT_CLOSED"},
+         {account_status::ACCOUNT_UPDATED, "ACCOUNT_UPDATED"},
+         {account_status::ACTION_REQUIRED, "ACTION_REQUIRED"},
+         {account_status::ACTIVE, "ACTIVE"},
+         {account_status::AML_REVIEW, "AML_REVIEW"},
+         {account_status::APPROVAL_PENDING, "APPROVAL_PENDING"},
+         {account_status::APPROVED, "APPROVED"},
+         {account_status::DISABLED, "DISABLED"},
+         {account_status::DISABLE_PENDING, "DISABLE_PENDING"},
+         {account_status::EDITED, "EDITED"},
+         {account_status::INACTIVE, "INACTIVE"},
+         {account_status::KYC_SUBMITTED, "KYC_SUBMITTED"},
+         {account_status::LIMITED, "LIMITED"},
+         {account_status::ONBOARDING, "ONBOARDING"},
+         {account_status::PAPER_ONLY, "PAPER_ONLY"},
+         {account_status::REAPPROVAL_PENDING, "REAPPROVAL_PENDING"},
+         {account_status::REJECTED, "REJECTED"},
+         {account_status::RESUBMITTED, "RESUBMITTED"},
+         {account_status::SIGNED_UP, "SIGNED_UP"},
+         {account_status::SUBMISSION_FAILED, "SUBMISSION_FAILED"},
+         {account_status::SUBMITTED, "SUBMITTED"}}};
+};
+
+template<>
+struct enum_mapping<asset_exchange>
+{
+    static constexpr std::array<std::pair<asset_exchange, std::string_view>, 13> mappings{
+        {{asset_exchange::AMEX, "AMEX"},
+         {asset_exchange::ARCA, "ARCA"},
+         {asset_exchange::BATS, "BATS"},
+         {asset_exchange::NYSE, "NYSE"},
+         {asset_exchange::NASDAQ, "NASDAQ"},
+         {asset_exchange::NYSEARCA, "NYSEARCA"},
+         {asset_exchange::OTC, "OTC"},
+         {asset_exchange::FTXU, "FTXU"},
+         {asset_exchange::CBSE, "CBSE"},
+         {asset_exchange::GNSS, "GNSS"},
+         {asset_exchange::ERSX, "ERSX"},
+         {asset_exchange::CRYPTO, "CRYPTO"},
+         {asset_exchange::EMPTY, ""}}};
+};
+
+template<>
+struct enum_mapping<asset_class>
+{
+    static constexpr std::array<std::pair<asset_class, std::string_view>, 3> mappings{
+        {{asset_class::US_EQUITY, "us_equity"},
+         {asset_class::US_OPTION, "us_option"},
+         {asset_class::CRYPTO, "crypto"}}};
+};
+
+template<>
+struct enum_mapping<position_side>
+{
+    static constexpr std::array<std::pair<position_side, std::string_view>, 2> mappings{
+        {{position_side::LONG, "long"}, {position_side::SHORT, "short"}}};
+};
+
+template<>
+struct enum_mapping<order_side>
+{
+    static constexpr std::array<std::pair<order_side, std::string_view>, 2> mappings{
+        {{order_side::BUY, "buy"}, {order_side::SELL, "sell"}}};
+};
+
+template<>
+struct enum_mapping<order_class>
+{
+    static constexpr std::array<std::pair<order_class, std::string_view>, 5> mappings{
+        {{order_class::SIMPLE, "simple"},
+         {order_class::BRACKET, "bracket"},
+         {order_class::OCO, "oco"},
+         {order_class::OTO, "oto"},
+         {order_class::MLEG, "mleg"}}};
+};
+
+template<>
+struct enum_mapping<order_type>
+{
+    static constexpr std::array<std::pair<order_type, std::string_view>, 5> mappings{
+        {{order_type::MARKET, "market"},
+         {order_type::LIMIT, "limit"},
+         {order_type::STOP, "stop"},
+         {order_type::STOP_LIMIT, "stop_limit"},
+         {order_type::TRAILING_STOP, "trailing_stop"}}};
+};
+
+template<>
+struct enum_mapping<time_in_force>
+{
+    static constexpr std::array<std::pair<time_in_force, std::string_view>, 6> mappings{
+        {{time_in_force::DAY, "day"},
+         {time_in_force::GTC, "gtc"},
+         {time_in_force::OPG, "opg"},
+         {time_in_force::CLS, "cls"},
+         {time_in_force::IOC, "ioc"},
+         {time_in_force::FOK, "fok"}}};
+};
+
+template<>
+struct enum_mapping<order_status>
+{
+    static constexpr std::array<std::pair<order_status, std::string_view>, 16> mappings{
+        {{order_status::NEW, "new"},
+         {order_status::PARTIALLY_FILLED, "partially_filled"},
+         {order_status::FILLED, "filled"},
+         {order_status::DONE_FOR_DAY, "done_for_day"},
+         {order_status::CANCELED, "canceled"},
+         {order_status::EXPIRED, "expired"},
+         {order_status::REPLACED, "replaced"},
+         {order_status::PENDING_CANCEL, "pending_cancel"},
+         {order_status::PENDING_REPLACE, "pending_replace"},
+         {order_status::ACCEPTED, "accepted"},
+         {order_status::PENDING_NEW, "pending_new"},
+         {order_status::ACCEPTED_FOR_BIDDING, "accepted_for_bidding"},
+         {order_status::STOPPED, "stopped"},
+         {order_status::REJECTED, "rejected"},
+         {order_status::SUSPENDED, "suspended"},
+         {order_status::CALCULATED, "calculated"}}};
+};
+
+template<>
+struct enum_mapping<position_intent>
+{
+    static constexpr std::array<std::pair<position_intent, std::string_view>, 4> mappings{
+        {{position_intent::BUY_TO_OPEN, "buy_to_open"},
+         {position_intent::BUY_TO_CLOSE, "buy_to_close"},
+         {position_intent::SELL_TO_OPEN, "sell_to_open"},
+         {position_intent::SELL_TO_CLOSE, "sell_to_close"}}};
+};
+
+template<typename EnumType>
+void enum_value_from_tag(json::value& jv, const EnumType& value)
+{
+    constexpr auto& mappings = enum_mapping<EnumType>::mappings;
+
+    auto it =
+        std::find_if(mappings.begin(), mappings.end(), [value](const auto& mapping) { return mapping.first == value; });
+
+    if (it != mappings.end())
+    {
+        jv = std::string{it->second};
+        return;
+    }
+
+    throw std::invalid_argument("Invalid enum value for serialization");
+}
+
+template<typename EnumType>
+EnumType enum_value_to_tag(const json::value& jv)
+{
+    const std::string value_str = json::value_to<std::string>(jv);
+    constexpr auto&   mappings  = enum_mapping<EnumType>::mappings;
+
+    auto it = std::find_if(
+        mappings.begin(), mappings.end(), [&value_str](const auto& mapping) { return mapping.second == value_str; });
+
+    if (it != mappings.end())
+    {
+        return it->first;
+    }
+
+    throw std::invalid_argument("Invalid enum string: " + value_str);
+}
+
+template<typename EnumType>
+EnumType enum_value_to_tag_with_fallback(const json::value& jv, EnumType fallback)
+{
+    const std::string value_str = json::value_to<std::string>(jv);
+    constexpr auto&   mappings  = enum_mapping<EnumType>::mappings;
+
+    auto it = std::find_if(
+        mappings.begin(), mappings.end(), [&value_str](const auto& mapping) { return mapping.second == value_str; });
+
+    if (it != mappings.end())
+    {
+        return it->first;
+    }
+
+    if (value_str.empty())
+    {
+        return fallback;
+    }
+
+    throw std::invalid_argument("Invalid enum string: " + value_str);
+}

--- a/alpaca_trade_client/include/alpaca_trade_client/orders.hpp
+++ b/alpaca_trade_client/include/alpaca_trade_client/orders.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "position.hpp"
-#include <nlohmann/json.hpp>
+#include <boost/json.hpp>
 #include <optional>
 #include <string>
 #include <vector>
@@ -130,32 +130,32 @@ struct notional_order
     std::string client_order_id{};
 };
 
-void to_json(nlohmann::json& j, const order_side& side);
-void from_json(const nlohmann::json& j, order_side& side);
+void       tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const order_side& side);
+order_side tag_invoke(boost::json::value_to_tag<order_side>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const order_class& oc);
-void from_json(const nlohmann::json& j, order_class& oc);
+void        tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const order_class& oc);
+order_class tag_invoke(boost::json::value_to_tag<order_class>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const order_type& ot);
-void from_json(const nlohmann::json& j, order_type& ot);
+void       tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const order_type& ot);
+order_type tag_invoke(boost::json::value_to_tag<order_type>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const time_in_force& tif);
-void from_json(const nlohmann::json& j, time_in_force& tif);
+void          tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const time_in_force& tif);
+time_in_force tag_invoke(boost::json::value_to_tag<time_in_force>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const order_status& os);
-void from_json(const nlohmann::json& j, order_status& os);
+void         tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const order_status& os);
+order_status tag_invoke(boost::json::value_to_tag<order_status>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const position_intent& pi);
-void from_json(const nlohmann::json& j, position_intent& pi);
+void            tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const position_intent& pi);
+position_intent tag_invoke(boost::json::value_to_tag<position_intent>, const boost::json::value& jv);
 
-void from_json(const nlohmann::json& j, order& o);
-void to_json(nlohmann::json& j, const order& o);
+void  tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const order& o);
+order tag_invoke(boost::json::value_to_tag<order>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const notional_order& order);
-void from_json(const nlohmann::json& j, notional_order& order);
+void           tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const notional_order& order);
+notional_order tag_invoke(boost::json::value_to_tag<notional_order>, const boost::json::value& jv);
 
-void from_json(const nlohmann::json& j, position_closed& pc);
-void to_json(nlohmann::json& j, const position_closed& pc);
+void            tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const position_closed& pc);
+position_closed tag_invoke(boost::json::value_to_tag<position_closed>, const boost::json::value& jv);
 
-void from_json(const nlohmann::json& j, order_deleted& od);
-void to_json(nlohmann::json& j, const order_deleted& od);
+void          tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const order_deleted& od);
+order_deleted tag_invoke(boost::json::value_to_tag<order_deleted>, const boost::json::value& jv);

--- a/alpaca_trade_client/include/alpaca_trade_client/position.hpp
+++ b/alpaca_trade_client/include/alpaca_trade_client/position.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <boost/json.hpp>
 #include <optional>
 #include <string>
 
@@ -56,14 +56,14 @@ struct position
     bool                       asset_marginable{};
 };
 
-void to_json(nlohmann::json& j, const asset_exchange& exchange);
-void from_json(const nlohmann::json& j, asset_exchange& exchange);
+void           tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const asset_exchange& exchange);
+asset_exchange tag_invoke(boost::json::value_to_tag<asset_exchange>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const asset_class& asset_class_type);
-void from_json(const nlohmann::json& j, asset_class& asset_class_type);
+void        tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const asset_class& asset_class_type);
+asset_class tag_invoke(boost::json::value_to_tag<asset_class>, const boost::json::value& jv);
 
-void to_json(nlohmann::json& j, const position_side& side);
-void from_json(const nlohmann::json& j, position_side& side);
+void          tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const position_side& side);
+position_side tag_invoke(boost::json::value_to_tag<position_side>, const boost::json::value& jv);
 
-void from_json(const nlohmann::json& j, position& pos);
-void to_json(nlohmann::json& j, const position& pos);
+void     tag_invoke(boost::json::value_from_tag, boost::json::value& jv, const position& pos);
+position tag_invoke(boost::json::value_to_tag<position>, const boost::json::value& jv);

--- a/alpaca_trade_client/src/alpaca_trade_client.cpp
+++ b/alpaca_trade_client/src/alpaca_trade_client.cpp
@@ -1,5 +1,5 @@
 #include "alpaca_trade_client/alpaca_trade_client.hpp"
-#include "nlohmann/json.hpp"
+#include <boost/json.hpp>
 
 //
 // alpaca_api_error class
@@ -94,13 +94,13 @@ net::awaitable<std::expected<std::vector<order_deleted>, alpaca_api_error>>
 
 net::awaitable<std::expected<order, alpaca_api_error>> alpaca_trade_client::create_order(const notional_order& no) const
 {
-    const nlohmann::json no_json = no;
+    const auto no_json = json::value_from(no);
 
     http::fields extra_headers;
     extra_headers.set(http::field::content_type, "application/json");
 
     co_return co_await make_api_request<http::verb::post, order>(
-        "/orders", no_json.dump(), http::status::ok, extra_headers);
+        "/orders", json::serialize(no_json), http::status::ok, extra_headers);
 }
 
 //
@@ -186,10 +186,11 @@ net::awaitable<std::expected<ReturnType, alpaca_api_error>> alpaca_trade_client:
 
     try
     {
-        const ReturnType result = nlohmann::json::parse(res.body());
+        auto             json_value = json::parse(res.body());
+        const ReturnType result     = json::value_to<ReturnType>(json_value);
         co_return result;
     }
-    catch (const nlohmann::json::exception& e)
+    catch (const std::exception& e)
     {
         const std::string error_msg = std::string(e.what()) + " | Response body: " + res.body();
         co_return std::unexpected{alpaca_api_error{

--- a/alpaca_trade_client/src/alpaca_trade_client.cpp
+++ b/alpaca_trade_client/src/alpaca_trade_client.cpp
@@ -190,9 +190,15 @@ net::awaitable<std::expected<ReturnType, alpaca_api_error>> alpaca_trade_client:
         const ReturnType result     = json::value_to<ReturnType>(json_value);
         co_return result;
     }
-    catch (const std::exception& e)
+    catch (const boost::system::system_error& e)
     {
         const std::string error_msg = std::string(e.what()) + " | Response body: " + res.body();
+        co_return std::unexpected{alpaca_api_error{
+            alpaca_api_error::error_type::json_parse_error, static_cast<int>(res.result()), error_msg}};
+    }
+    catch (const std::exception& e)
+    {
+        const std::string error_msg = std::string("Unexpected error: ") + e.what() + " | Response body: " + res.body();
         co_return std::unexpected{alpaca_api_error{
             alpaca_api_error::error_type::json_parse_error, static_cast<int>(res.result()), error_msg}};
     }

--- a/alpaca_trade_client/src/json_utils.cpp
+++ b/alpaca_trade_client/src/json_utils.cpp
@@ -4,891 +4,935 @@
 
 //
 // account.hpp JSON serialization implementations
+//
 
-void to_json(nlohmann::json& j, const account_status& status)
+namespace json = boost::json;
+
+void tag_invoke(json::value_from_tag, json::value& jv, const account_status& status)
 {
     switch (status)
     {
         case account_status::ACCOUNT_CLOSED:
-            j = "ACCOUNT_CLOSED";
+            jv = "ACCOUNT_CLOSED";
             break;
         case account_status::ACCOUNT_UPDATED:
-            j = "ACCOUNT_UPDATED";
+            jv = "ACCOUNT_UPDATED";
             break;
         case account_status::ACTION_REQUIRED:
-            j = "ACTION_REQUIRED";
+            jv = "ACTION_REQUIRED";
             break;
         case account_status::ACTIVE:
-            j = "ACTIVE";
+            jv = "ACTIVE";
             break;
         case account_status::AML_REVIEW:
-            j = "AML_REVIEW";
+            jv = "AML_REVIEW";
             break;
         case account_status::APPROVAL_PENDING:
-            j = "APPROVAL_PENDING";
+            jv = "APPROVAL_PENDING";
             break;
         case account_status::APPROVED:
-            j = "APPROVED";
+            jv = "APPROVED";
             break;
         case account_status::DISABLED:
-            j = "DISABLED";
+            jv = "DISABLED";
             break;
         case account_status::DISABLE_PENDING:
-            j = "DISABLE_PENDING";
+            jv = "DISABLE_PENDING";
             break;
         case account_status::EDITED:
-            j = "EDITED";
+            jv = "EDITED";
             break;
         case account_status::INACTIVE:
-            j = "INACTIVE";
+            jv = "INACTIVE";
             break;
         case account_status::KYC_SUBMITTED:
-            j = "KYC_SUBMITTED";
+            jv = "KYC_SUBMITTED";
             break;
         case account_status::LIMITED:
-            j = "LIMITED";
+            jv = "LIMITED";
             break;
         case account_status::ONBOARDING:
-            j = "ONBOARDING";
+            jv = "ONBOARDING";
             break;
         case account_status::PAPER_ONLY:
-            j = "PAPER_ONLY";
+            jv = "PAPER_ONLY";
             break;
         case account_status::REAPPROVAL_PENDING:
-            j = "REAPPROVAL_PENDING";
+            jv = "REAPPROVAL_PENDING";
             break;
         case account_status::REJECTED:
-            j = "REJECTED";
+            jv = "REJECTED";
             break;
         case account_status::RESUBMITTED:
-            j = "RESUBMITTED";
+            jv = "RESUBMITTED";
             break;
         case account_status::SIGNED_UP:
-            j = "SIGNED_UP";
+            jv = "SIGNED_UP";
             break;
         case account_status::SUBMISSION_FAILED:
-            j = "SUBMISSION_FAILED";
+            jv = "SUBMISSION_FAILED";
             break;
         case account_status::SUBMITTED:
-            j = "SUBMITTED";
+            jv = "SUBMITTED";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, account_status& status)
+account_status tag_invoke(json::value_to_tag<account_status>, const json::value& jv)
 {
-    const std::string status_str = j.get<std::string>();
+    const std::string status_str = json::value_to<std::string>(jv);
     if (status_str == "ACCOUNT_CLOSED")
-        status = account_status::ACCOUNT_CLOSED;
-    else if (status_str == "ACCOUNT_UPDATED")
-        status = account_status::ACCOUNT_UPDATED;
-    else if (status_str == "ACTION_REQUIRED")
-        status = account_status::ACTION_REQUIRED;
-    else if (status_str == "ACTIVE")
-        status = account_status::ACTIVE;
-    else if (status_str == "AML_REVIEW")
-        status = account_status::AML_REVIEW;
-    else if (status_str == "APPROVAL_PENDING")
-        status = account_status::APPROVAL_PENDING;
-    else if (status_str == "APPROVED")
-        status = account_status::APPROVED;
-    else if (status_str == "DISABLED")
-        status = account_status::DISABLED;
-    else if (status_str == "DISABLE_PENDING")
-        status = account_status::DISABLE_PENDING;
-    else if (status_str == "EDITED")
-        status = account_status::EDITED;
-    else if (status_str == "INACTIVE")
-        status = account_status::INACTIVE;
-    else if (status_str == "KYC_SUBMITTED")
-        status = account_status::KYC_SUBMITTED;
-    else if (status_str == "LIMITED")
-        status = account_status::LIMITED;
-    else if (status_str == "ONBOARDING")
-        status = account_status::ONBOARDING;
-    else if (status_str == "PAPER_ONLY")
-        status = account_status::PAPER_ONLY;
-    else if (status_str == "REAPPROVAL_PENDING")
-        status = account_status::REAPPROVAL_PENDING;
-    else if (status_str == "REJECTED")
-        status = account_status::REJECTED;
-    else if (status_str == "RESUBMITTED")
-        status = account_status::RESUBMITTED;
-    else if (status_str == "SIGNED_UP")
-        status = account_status::SIGNED_UP;
-    else if (status_str == "SUBMISSION_FAILED")
-        status = account_status::SUBMISSION_FAILED;
-    else if (status_str == "SUBMITTED")
-        status = account_status::SUBMITTED;
-    else
-        throw std::invalid_argument("Invalid account_status: " + status_str);
+        return account_status::ACCOUNT_CLOSED;
+    if (status_str == "ACCOUNT_UPDATED")
+        return account_status::ACCOUNT_UPDATED;
+    if (status_str == "ACTION_REQUIRED")
+        return account_status::ACTION_REQUIRED;
+    if (status_str == "ACTIVE")
+        return account_status::ACTIVE;
+    if (status_str == "AML_REVIEW")
+        return account_status::AML_REVIEW;
+    if (status_str == "APPROVAL_PENDING")
+        return account_status::APPROVAL_PENDING;
+    if (status_str == "APPROVED")
+        return account_status::APPROVED;
+    if (status_str == "DISABLED")
+        return account_status::DISABLED;
+    if (status_str == "DISABLE_PENDING")
+        return account_status::DISABLE_PENDING;
+    if (status_str == "EDITED")
+        return account_status::EDITED;
+    if (status_str == "INACTIVE")
+        return account_status::INACTIVE;
+    if (status_str == "KYC_SUBMITTED")
+        return account_status::KYC_SUBMITTED;
+    if (status_str == "LIMITED")
+        return account_status::LIMITED;
+    if (status_str == "ONBOARDING")
+        return account_status::ONBOARDING;
+    if (status_str == "PAPER_ONLY")
+        return account_status::PAPER_ONLY;
+    if (status_str == "REAPPROVAL_PENDING")
+        return account_status::REAPPROVAL_PENDING;
+    if (status_str == "REJECTED")
+        return account_status::REJECTED;
+    if (status_str == "RESUBMITTED")
+        return account_status::RESUBMITTED;
+    if (status_str == "SIGNED_UP")
+        return account_status::SIGNED_UP;
+    if (status_str == "SUBMISSION_FAILED")
+        return account_status::SUBMISSION_FAILED;
+    if (status_str == "SUBMITTED")
+        return account_status::SUBMITTED;
+    throw std::invalid_argument("Invalid account_status: " + status_str);
 }
 
-void from_json(const nlohmann::json& j, trade_account& account)
+trade_account tag_invoke(json::value_to_tag<trade_account>, const json::value& jv)
 {
-    j.at("id").get_to(account.id);
-    j.at("status").get_to(account.status);
-    j.at("currency").get_to(account.currency);
+    const auto&   obj = jv.as_object();
+    trade_account account;
 
-    if (j.contains("account_number") && !j.at("account_number").is_null())
-        account.account_number = j.at("account_number").get<std::string>();
-    if (j.contains("cash") && !j.at("cash").is_null())
-        account.cash = j.at("cash").get<std::string>();
-    if (j.contains("portfolio_value") && !j.at("portfolio_value").is_null())
-        account.portfolio_value = j.at("portfolio_value").get<std::string>();
-    if (j.contains("non_marginable_buying_power") && !j.at("non_marginable_buying_power").is_null())
-        account.non_marginable_buying_power = j.at("non_marginable_buying_power").get<std::string>();
-    if (j.contains("accrued_fees") && !j.at("accrued_fees").is_null())
-        account.accrued_fees = j.at("accrued_fees").get<std::string>();
-    if (j.contains("pending_transfer_in") && !j.at("pending_transfer_in").is_null())
-        account.pending_transfer_in = j.at("pending_transfer_in").get<std::string>();
-    if (j.contains("pending_transfer_out") && !j.at("pending_transfer_out").is_null())
-        account.pending_transfer_out = j.at("pending_transfer_out").get<std::string>();
-    if (j.contains("created_at") && !j.at("created_at").is_null())
-        account.created_at = j.at("created_at").get<std::string>();
-    if (j.contains("long_market_value") && !j.at("long_market_value").is_null())
-        account.long_market_value = j.at("long_market_value").get<std::string>();
-    if (j.contains("short_market_value") && !j.at("short_market_value").is_null())
-        account.short_market_value = j.at("short_market_value").get<std::string>();
-    if (j.contains("equity") && !j.at("equity").is_null())
-        account.equity = j.at("equity").get<std::string>();
-    if (j.contains("last_equity") && !j.at("last_equity").is_null())
-        account.last_equity = j.at("last_equity").get<std::string>();
-    if (j.contains("multiplier") && !j.at("multiplier").is_null())
-        account.multiplier = j.at("multiplier").get<std::string>();
-    if (j.contains("buying_power") && !j.at("buying_power").is_null())
-        account.buying_power = j.at("buying_power").get<std::string>();
-    if (j.contains("initial_margin") && !j.at("initial_margin").is_null())
-        account.initial_margin = j.at("initial_margin").get<std::string>();
-    if (j.contains("maintenance_margin") && !j.at("maintenance_margin").is_null())
-        account.maintenance_margin = j.at("maintenance_margin").get<std::string>();
-    if (j.contains("sma") && !j.at("sma").is_null())
-        account.sma = j.at("sma").get<std::string>();
-    if (j.contains("balance_asof") && !j.at("balance_asof").is_null())
-        account.balance_asof = j.at("balance_asof").get<std::string>();
-    if (j.contains("last_maintenance_margin") && !j.at("last_maintenance_margin").is_null())
-        account.last_maintenance_margin = j.at("last_maintenance_margin").get<std::string>();
-    if (j.contains("daytrading_buying_power") && !j.at("daytrading_buying_power").is_null())
-        account.daytrading_buying_power = j.at("daytrading_buying_power").get<std::string>();
-    if (j.contains("regt_buying_power") && !j.at("regt_buying_power").is_null())
-        account.regt_buying_power = j.at("regt_buying_power").get<std::string>();
-    if (j.contains("options_buying_power") && !j.at("options_buying_power").is_null())
-        account.options_buying_power = j.at("options_buying_power").get<std::string>();
-    if (j.contains("intraday_adjustments") && !j.at("intraday_adjustments").is_null())
-        account.intraday_adjustments = j.at("intraday_adjustments").get<std::string>();
-    if (j.contains("pending_reg_taf_fees") && !j.at("pending_reg_taf_fees").is_null())
-        account.pending_reg_taf_fees = j.at("pending_reg_taf_fees").get<std::string>();
-    if (j.contains("daytrade_count") && !j.at("daytrade_count").is_null())
-        account.daytrade_count = j.at("daytrade_count").get<int>();
-    if (j.contains("options_approved_level") && !j.at("options_approved_level").is_null())
-        account.options_approved_level = j.at("options_approved_level").get<int>();
-    if (j.contains("options_trading_level") && !j.at("options_trading_level").is_null())
-        account.options_trading_level = j.at("options_trading_level").get<int>();
-    if (j.contains("pattern_day_trader") && !j.at("pattern_day_trader").is_null())
-        account.pattern_day_trader = j.at("pattern_day_trader").get<bool>();
-    if (j.contains("trade_suspended_by_user") && !j.at("trade_suspended_by_user").is_null())
-        account.trade_suspended_by_user = j.at("trade_suspended_by_user").get<bool>();
-    if (j.contains("trading_blocked") && !j.at("trading_blocked").is_null())
-        account.trading_blocked = j.at("trading_blocked").get<bool>();
-    if (j.contains("transfers_blocked") && !j.at("transfers_blocked").is_null())
-        account.transfers_blocked = j.at("transfers_blocked").get<bool>();
-    if (j.contains("account_blocked") && !j.at("account_blocked").is_null())
-        account.account_blocked = j.at("account_blocked").get<bool>();
-    if (j.contains("shorting_enabled") && !j.at("shorting_enabled").is_null())
-        account.shorting_enabled = j.at("shorting_enabled").get<bool>();
+    account.id       = json::value_to<std::string>(obj.at("id"));
+    account.status   = json::value_to<account_status>(obj.at("status"));
+    account.currency = json::value_to<std::string>(obj.at("currency"));
+
+    if (obj.contains("account_number") && !obj.at("account_number").is_null())
+        account.account_number = json::value_to<std::string>(obj.at("account_number"));
+    if (obj.contains("cash") && !obj.at("cash").is_null())
+        account.cash = json::value_to<std::string>(obj.at("cash"));
+    if (obj.contains("portfolio_value") && !obj.at("portfolio_value").is_null())
+        account.portfolio_value = json::value_to<std::string>(obj.at("portfolio_value"));
+    if (obj.contains("non_marginable_buying_power") && !obj.at("non_marginable_buying_power").is_null())
+        account.non_marginable_buying_power = json::value_to<std::string>(obj.at("non_marginable_buying_power"));
+    if (obj.contains("accrued_fees") && !obj.at("accrued_fees").is_null())
+        account.accrued_fees = json::value_to<std::string>(obj.at("accrued_fees"));
+    if (obj.contains("pending_transfer_in") && !obj.at("pending_transfer_in").is_null())
+        account.pending_transfer_in = json::value_to<std::string>(obj.at("pending_transfer_in"));
+    if (obj.contains("pending_transfer_out") && !obj.at("pending_transfer_out").is_null())
+        account.pending_transfer_out = json::value_to<std::string>(obj.at("pending_transfer_out"));
+    if (obj.contains("created_at") && !obj.at("created_at").is_null())
+        account.created_at = json::value_to<std::string>(obj.at("created_at"));
+    if (obj.contains("long_market_value") && !obj.at("long_market_value").is_null())
+        account.long_market_value = json::value_to<std::string>(obj.at("long_market_value"));
+    if (obj.contains("short_market_value") && !obj.at("short_market_value").is_null())
+        account.short_market_value = json::value_to<std::string>(obj.at("short_market_value"));
+    if (obj.contains("equity") && !obj.at("equity").is_null())
+        account.equity = json::value_to<std::string>(obj.at("equity"));
+    if (obj.contains("last_equity") && !obj.at("last_equity").is_null())
+        account.last_equity = json::value_to<std::string>(obj.at("last_equity"));
+    if (obj.contains("multiplier") && !obj.at("multiplier").is_null())
+        account.multiplier = json::value_to<std::string>(obj.at("multiplier"));
+    if (obj.contains("buying_power") && !obj.at("buying_power").is_null())
+        account.buying_power = json::value_to<std::string>(obj.at("buying_power"));
+    if (obj.contains("initial_margin") && !obj.at("initial_margin").is_null())
+        account.initial_margin = json::value_to<std::string>(obj.at("initial_margin"));
+    if (obj.contains("maintenance_margin") && !obj.at("maintenance_margin").is_null())
+        account.maintenance_margin = json::value_to<std::string>(obj.at("maintenance_margin"));
+    if (obj.contains("sma") && !obj.at("sma").is_null())
+        account.sma = json::value_to<std::string>(obj.at("sma"));
+    if (obj.contains("balance_asof") && !obj.at("balance_asof").is_null())
+        account.balance_asof = json::value_to<std::string>(obj.at("balance_asof"));
+    if (obj.contains("last_maintenance_margin") && !obj.at("last_maintenance_margin").is_null())
+        account.last_maintenance_margin = json::value_to<std::string>(obj.at("last_maintenance_margin"));
+    if (obj.contains("daytrading_buying_power") && !obj.at("daytrading_buying_power").is_null())
+        account.daytrading_buying_power = json::value_to<std::string>(obj.at("daytrading_buying_power"));
+    if (obj.contains("regt_buying_power") && !obj.at("regt_buying_power").is_null())
+        account.regt_buying_power = json::value_to<std::string>(obj.at("regt_buying_power"));
+    if (obj.contains("options_buying_power") && !obj.at("options_buying_power").is_null())
+        account.options_buying_power = json::value_to<std::string>(obj.at("options_buying_power"));
+    if (obj.contains("intraday_adjustments") && !obj.at("intraday_adjustments").is_null())
+        account.intraday_adjustments = json::value_to<std::string>(obj.at("intraday_adjustments"));
+    if (obj.contains("pending_reg_taf_fees") && !obj.at("pending_reg_taf_fees").is_null())
+        account.pending_reg_taf_fees = json::value_to<std::string>(obj.at("pending_reg_taf_fees"));
+    if (obj.contains("daytrade_count") && !obj.at("daytrade_count").is_null())
+        account.daytrade_count = json::value_to<int>(obj.at("daytrade_count"));
+    if (obj.contains("options_approved_level") && !obj.at("options_approved_level").is_null())
+        account.options_approved_level = json::value_to<int>(obj.at("options_approved_level"));
+    if (obj.contains("options_trading_level") && !obj.at("options_trading_level").is_null())
+        account.options_trading_level = json::value_to<int>(obj.at("options_trading_level"));
+    if (obj.contains("pattern_day_trader") && !obj.at("pattern_day_trader").is_null())
+        account.pattern_day_trader = json::value_to<bool>(obj.at("pattern_day_trader"));
+    if (obj.contains("trade_suspended_by_user") && !obj.at("trade_suspended_by_user").is_null())
+        account.trade_suspended_by_user = json::value_to<bool>(obj.at("trade_suspended_by_user"));
+    if (obj.contains("trading_blocked") && !obj.at("trading_blocked").is_null())
+        account.trading_blocked = json::value_to<bool>(obj.at("trading_blocked"));
+    if (obj.contains("transfers_blocked") && !obj.at("transfers_blocked").is_null())
+        account.transfers_blocked = json::value_to<bool>(obj.at("transfers_blocked"));
+    if (obj.contains("account_blocked") && !obj.at("account_blocked").is_null())
+        account.account_blocked = json::value_to<bool>(obj.at("account_blocked"));
+    if (obj.contains("shorting_enabled") && !obj.at("shorting_enabled").is_null())
+        account.shorting_enabled = json::value_to<bool>(obj.at("shorting_enabled"));
+
+    return account;
 }
 
-void to_json(nlohmann::json& j, const trade_account& account)
+void tag_invoke(json::value_from_tag, json::value& jv, const trade_account& account)
 {
-    j = nlohmann::json{{"id", account.id}, {"currency", account.currency}, {"status", account.status}};
+    json::object obj;
+    obj["id"]       = account.id;
+    obj["currency"] = account.currency;
+    obj["status"]   = json::value_from(account.status);
 
     if (account.account_number.has_value())
-        j["account_number"] = account.account_number.value();
+        obj["account_number"] = account.account_number.value();
     if (account.cash.has_value())
-        j["cash"] = account.cash.value();
+        obj["cash"] = account.cash.value();
     if (account.portfolio_value.has_value())
-        j["portfolio_value"] = account.portfolio_value.value();
+        obj["portfolio_value"] = account.portfolio_value.value();
     if (account.non_marginable_buying_power.has_value())
-        j["non_marginable_buying_power"] = account.non_marginable_buying_power.value();
+        obj["non_marginable_buying_power"] = account.non_marginable_buying_power.value();
     if (account.accrued_fees.has_value())
-        j["accrued_fees"] = account.accrued_fees.value();
+        obj["accrued_fees"] = account.accrued_fees.value();
     if (account.pending_transfer_in.has_value())
-        j["pending_transfer_in"] = account.pending_transfer_in.value();
+        obj["pending_transfer_in"] = account.pending_transfer_in.value();
     if (account.pending_transfer_out.has_value())
-        j["pending_transfer_out"] = account.pending_transfer_out.value();
+        obj["pending_transfer_out"] = account.pending_transfer_out.value();
     if (account.created_at.has_value())
-        j["created_at"] = account.created_at.value();
+        obj["created_at"] = account.created_at.value();
     if (account.long_market_value.has_value())
-        j["long_market_value"] = account.long_market_value.value();
+        obj["long_market_value"] = account.long_market_value.value();
     if (account.short_market_value.has_value())
-        j["short_market_value"] = account.short_market_value.value();
+        obj["short_market_value"] = account.short_market_value.value();
     if (account.equity.has_value())
-        j["equity"] = account.equity.value();
+        obj["equity"] = account.equity.value();
     if (account.last_equity.has_value())
-        j["last_equity"] = account.last_equity.value();
+        obj["last_equity"] = account.last_equity.value();
     if (account.multiplier.has_value())
-        j["multiplier"] = account.multiplier.value();
+        obj["multiplier"] = account.multiplier.value();
     if (account.buying_power.has_value())
-        j["buying_power"] = account.buying_power.value();
+        obj["buying_power"] = account.buying_power.value();
     if (account.initial_margin.has_value())
-        j["initial_margin"] = account.initial_margin.value();
+        obj["initial_margin"] = account.initial_margin.value();
     if (account.maintenance_margin.has_value())
-        j["maintenance_margin"] = account.maintenance_margin.value();
+        obj["maintenance_margin"] = account.maintenance_margin.value();
     if (account.sma.has_value())
-        j["sma"] = account.sma.value();
+        obj["sma"] = account.sma.value();
     if (account.balance_asof.has_value())
-        j["balance_asof"] = account.balance_asof.value();
+        obj["balance_asof"] = account.balance_asof.value();
     if (account.last_maintenance_margin.has_value())
-        j["last_maintenance_margin"] = account.last_maintenance_margin.value();
+        obj["last_maintenance_margin"] = account.last_maintenance_margin.value();
     if (account.daytrading_buying_power.has_value())
-        j["daytrading_buying_power"] = account.daytrading_buying_power.value();
+        obj["daytrading_buying_power"] = account.daytrading_buying_power.value();
     if (account.regt_buying_power.has_value())
-        j["regt_buying_power"] = account.regt_buying_power.value();
+        obj["regt_buying_power"] = account.regt_buying_power.value();
     if (account.options_buying_power.has_value())
-        j["options_buying_power"] = account.options_buying_power.value();
+        obj["options_buying_power"] = account.options_buying_power.value();
     if (account.intraday_adjustments.has_value())
-        j["intraday_adjustments"] = account.intraday_adjustments.value();
+        obj["intraday_adjustments"] = account.intraday_adjustments.value();
     if (account.pending_reg_taf_fees.has_value())
-        j["pending_reg_taf_fees"] = account.pending_reg_taf_fees.value();
+        obj["pending_reg_taf_fees"] = account.pending_reg_taf_fees.value();
     if (account.daytrade_count.has_value())
-        j["daytrade_count"] = account.daytrade_count.value();
+        obj["daytrade_count"] = account.daytrade_count.value();
     if (account.options_approved_level.has_value())
-        j["options_approved_level"] = account.options_approved_level.value();
+        obj["options_approved_level"] = account.options_approved_level.value();
     if (account.options_trading_level.has_value())
-        j["options_trading_level"] = account.options_trading_level.value();
+        obj["options_trading_level"] = account.options_trading_level.value();
     if (account.pattern_day_trader.has_value())
-        j["pattern_day_trader"] = account.pattern_day_trader.value();
+        obj["pattern_day_trader"] = account.pattern_day_trader.value();
     if (account.trade_suspended_by_user.has_value())
-        j["trade_suspended_by_user"] = account.trade_suspended_by_user.value();
+        obj["trade_suspended_by_user"] = account.trade_suspended_by_user.value();
     if (account.trading_blocked.has_value())
-        j["trading_blocked"] = account.trading_blocked.value();
+        obj["trading_blocked"] = account.trading_blocked.value();
     if (account.transfers_blocked.has_value())
-        j["transfers_blocked"] = account.transfers_blocked.value();
+        obj["transfers_blocked"] = account.transfers_blocked.value();
     if (account.account_blocked.has_value())
-        j["account_blocked"] = account.account_blocked.value();
+        obj["account_blocked"] = account.account_blocked.value();
     if (account.shorting_enabled.has_value())
-        j["shorting_enabled"] = account.shorting_enabled.value();
+        obj["shorting_enabled"] = account.shorting_enabled.value();
+
+    jv = std::move(obj);
 }
 
 //
 // position.hpp JSON serialization implementations
+//
 
-void to_json(nlohmann::json& j, const asset_exchange& exchange)
+void tag_invoke(json::value_from_tag, json::value& jv, const asset_exchange& exchange)
 {
     switch (exchange)
     {
         case asset_exchange::AMEX:
-            j = "AMEX";
+            jv = "AMEX";
             break;
         case asset_exchange::ARCA:
-            j = "ARCA";
+            jv = "ARCA";
             break;
         case asset_exchange::BATS:
-            j = "BATS";
+            jv = "BATS";
             break;
         case asset_exchange::NYSE:
-            j = "NYSE";
+            jv = "NYSE";
             break;
         case asset_exchange::NASDAQ:
-            j = "NASDAQ";
+            jv = "NASDAQ";
             break;
         case asset_exchange::NYSEARCA:
-            j = "NYSEARCA";
+            jv = "NYSEARCA";
             break;
         case asset_exchange::OTC:
-            j = "OTC";
+            jv = "OTC";
             break;
         case asset_exchange::FTXU:
-            j = "FTXU";
+            jv = "FTXU";
             break;
         case asset_exchange::CBSE:
-            j = "CBSE";
+            jv = "CBSE";
             break;
         case asset_exchange::GNSS:
-            j = "GNSS";
+            jv = "GNSS";
             break;
         case asset_exchange::ERSX:
-            j = "ERSX";
+            jv = "ERSX";
             break;
         case asset_exchange::CRYPTO:
-            j = "CRYPTO";
+            jv = "CRYPTO";
             break;
         case asset_exchange::EMPTY:
-            j = "";
+            jv = "";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, asset_exchange& exchange)
+asset_exchange tag_invoke(json::value_to_tag<asset_exchange>, const json::value& jv)
 {
-    if (const std::string exchange_str = j; exchange_str == "AMEX")
-        exchange = asset_exchange::AMEX;
-    else if (exchange_str == "ARCA")
-        exchange = asset_exchange::ARCA;
-    else if (exchange_str == "BATS")
-        exchange = asset_exchange::BATS;
-    else if (exchange_str == "NYSE")
-        exchange = asset_exchange::NYSE;
-    else if (exchange_str == "NASDAQ")
-        exchange = asset_exchange::NASDAQ;
-    else if (exchange_str == "NYSEARCA")
-        exchange = asset_exchange::NYSEARCA;
-    else if (exchange_str == "OTC")
-        exchange = asset_exchange::OTC;
-    else if (exchange_str == "FTXU")
-        exchange = asset_exchange::FTXU;
-    else if (exchange_str == "CBSE")
-        exchange = asset_exchange::CBSE;
-    else if (exchange_str == "GNSS")
-        exchange = asset_exchange::GNSS;
-    else if (exchange_str == "ERSX")
-        exchange = asset_exchange::ERSX;
-    else if (exchange_str == "CRYPTO")
-        exchange = asset_exchange::CRYPTO;
-    else if (exchange_str == "")
-        exchange = asset_exchange::EMPTY;
-    else
-        throw std::invalid_argument("Invalid asset_exchange: " + exchange_str);
+    const std::string exchange_str = json::value_to<std::string>(jv);
+    if (exchange_str == "AMEX")
+        return asset_exchange::AMEX;
+    if (exchange_str == "ARCA")
+        return asset_exchange::ARCA;
+    if (exchange_str == "BATS")
+        return asset_exchange::BATS;
+    if (exchange_str == "NYSE")
+        return asset_exchange::NYSE;
+    if (exchange_str == "NASDAQ")
+        return asset_exchange::NASDAQ;
+    if (exchange_str == "NYSEARCA")
+        return asset_exchange::NYSEARCA;
+    if (exchange_str == "OTC")
+        return asset_exchange::OTC;
+    if (exchange_str == "FTXU")
+        return asset_exchange::FTXU;
+    if (exchange_str == "CBSE")
+        return asset_exchange::CBSE;
+    if (exchange_str == "GNSS")
+        return asset_exchange::GNSS;
+    if (exchange_str == "ERSX")
+        return asset_exchange::ERSX;
+    if (exchange_str == "CRYPTO")
+        return asset_exchange::CRYPTO;
+    if (exchange_str == "")
+        return asset_exchange::EMPTY;
+    throw std::invalid_argument("Invalid asset_exchange: " + exchange_str);
 }
 
-void to_json(nlohmann::json& j, const asset_class& asset_class_type)
+void tag_invoke(json::value_from_tag, json::value& jv, const asset_class& asset_class_type)
 {
     switch (asset_class_type)
     {
         case asset_class::US_EQUITY:
-            j = "us_equity";
+            jv = "us_equity";
             break;
         case asset_class::US_OPTION:
-            j = "us_option";
+            jv = "us_option";
             break;
         case asset_class::CRYPTO:
-            j = "crypto";
+            jv = "crypto";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, asset_class& asset_class_type)
+asset_class tag_invoke(json::value_to_tag<asset_class>, const json::value& jv)
 {
-    if (const std::string class_str = j; class_str == "us_equity")
-        asset_class_type = asset_class::US_EQUITY;
-    else if (class_str == "us_option")
-        asset_class_type = asset_class::US_OPTION;
-    else if (class_str == "crypto")
-        asset_class_type = asset_class::CRYPTO;
-    else
-        throw std::invalid_argument("Invalid asset_class: " + class_str);
+    const std::string class_str = json::value_to<std::string>(jv);
+    if (class_str == "us_equity")
+        return asset_class::US_EQUITY;
+    if (class_str == "us_option")
+        return asset_class::US_OPTION;
+    if (class_str == "crypto")
+        return asset_class::CRYPTO;
+    throw std::invalid_argument("Invalid asset_class: " + class_str);
 }
 
-void to_json(nlohmann::json& j, const position_side& side)
+void tag_invoke(json::value_from_tag, json::value& jv, const position_side& side)
 {
     switch (side)
     {
         case position_side::LONG:
-            j = "long";
+            jv = "long";
             break;
         case position_side::SHORT:
-            j = "short";
+            jv = "short";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, position_side& side)
+position_side tag_invoke(json::value_to_tag<position_side>, const json::value& jv)
 {
-    if (const std::string side_str = j; side_str == "long")
-        side = position_side::LONG;
-    else if (side_str == "short")
-        side = position_side::SHORT;
-    else
-        throw std::invalid_argument("Invalid position_side: " + side_str);
+    const std::string side_str = json::value_to<std::string>(jv);
+    if (side_str == "long")
+        return position_side::LONG;
+    if (side_str == "short")
+        return position_side::SHORT;
+    throw std::invalid_argument("Invalid position_side: " + side_str);
 }
 
-void from_json(const nlohmann::json& j, position& pos)
+position tag_invoke(json::value_to_tag<position>, const json::value& jv)
 {
-    j.at("asset_id").get_to(pos.asset_id);
-    j.at("symbol").get_to(pos.symbol);
-    j.at("exchange").get_to(pos.exchange);
-    j.at("asset_class").get_to(pos.asset_class_type);
-    j.at("avg_entry_price").get_to(pos.avg_entry_price);
-    j.at("qty").get_to(pos.qty);
-    j.at("side").get_to(pos.side);
-    j.at("market_value").get_to(pos.market_value);
-    j.at("cost_basis").get_to(pos.cost_basis);
-    j.at("unrealized_pl").get_to(pos.unrealized_pl);
-    j.at("unrealized_plpc").get_to(pos.unrealized_plpc);
-    j.at("unrealized_intraday_pl").get_to(pos.unrealized_intraday_pl);
-    j.at("unrealized_intraday_plpc").get_to(pos.unrealized_intraday_plpc);
-    j.at("current_price").get_to(pos.current_price);
-    j.at("lastday_price").get_to(pos.lastday_price);
-    j.at("change_today").get_to(pos.change_today);
-    j.at("asset_marginable").get_to(pos.asset_marginable);
+    const auto& obj = jv.as_object();
+    position    pos;
 
-    if (j.contains("qty_available") && !j.at("qty_available").is_null())
-        pos.qty_available = j.at("qty_available").get<std::string>();
+    pos.asset_id                 = json::value_to<std::string>(obj.at("asset_id"));
+    pos.symbol                   = json::value_to<std::string>(obj.at("symbol"));
+    pos.exchange                 = json::value_to<asset_exchange>(obj.at("exchange"));
+    pos.asset_class_type         = json::value_to<asset_class>(obj.at("asset_class"));
+    pos.avg_entry_price          = json::value_to<std::string>(obj.at("avg_entry_price"));
+    pos.qty                      = json::value_to<std::string>(obj.at("qty"));
+    pos.side                     = json::value_to<position_side>(obj.at("side"));
+    pos.market_value             = json::value_to<std::string>(obj.at("market_value"));
+    pos.cost_basis               = json::value_to<std::string>(obj.at("cost_basis"));
+    pos.unrealized_pl            = json::value_to<std::string>(obj.at("unrealized_pl"));
+    pos.unrealized_plpc          = json::value_to<std::string>(obj.at("unrealized_plpc"));
+    pos.unrealized_intraday_pl   = json::value_to<std::string>(obj.at("unrealized_intraday_pl"));
+    pos.unrealized_intraday_plpc = json::value_to<std::string>(obj.at("unrealized_intraday_plpc"));
+    pos.current_price            = json::value_to<std::string>(obj.at("current_price"));
+    pos.lastday_price            = json::value_to<std::string>(obj.at("lastday_price"));
+    pos.change_today             = json::value_to<std::string>(obj.at("change_today"));
+    pos.asset_marginable         = json::value_to<bool>(obj.at("asset_marginable"));
+
+    if (obj.contains("qty_available") && !obj.at("qty_available").is_null())
+        pos.qty_available = json::value_to<std::string>(obj.at("qty_available"));
+
+    return pos;
 }
 
-void to_json(nlohmann::json& j, const position& pos)
+void tag_invoke(json::value_from_tag, json::value& jv, const position& pos)
 {
-    j = nlohmann::json{
-        {"asset_id", pos.asset_id},
-        {"symbol", pos.symbol},
-        {"exchange", pos.exchange},
-        {"asset_class", pos.asset_class_type},
-        {"avg_entry_price", pos.avg_entry_price},
-        {"qty", pos.qty},
-        {"side", pos.side},
-        {"market_value", pos.market_value},
-        {"cost_basis", pos.cost_basis},
-        {"unrealized_pl", pos.unrealized_pl},
-        {"unrealized_plpc", pos.unrealized_plpc},
-        {"unrealized_intraday_pl", pos.unrealized_intraday_pl},
-        {"unrealized_intraday_plpc", pos.unrealized_intraday_plpc},
-        {"current_price", pos.current_price},
-        {"lastday_price", pos.lastday_price},
-        {"change_today", pos.change_today},
-        {"asset_marginable", pos.asset_marginable}};
+    json::object obj;
+    obj["asset_id"]                 = pos.asset_id;
+    obj["symbol"]                   = pos.symbol;
+    obj["exchange"]                 = json::value_from(pos.exchange);
+    obj["asset_class"]              = json::value_from(pos.asset_class_type);
+    obj["avg_entry_price"]          = pos.avg_entry_price;
+    obj["qty"]                      = pos.qty;
+    obj["side"]                     = json::value_from(pos.side);
+    obj["market_value"]             = pos.market_value;
+    obj["cost_basis"]               = pos.cost_basis;
+    obj["unrealized_pl"]            = pos.unrealized_pl;
+    obj["unrealized_plpc"]          = pos.unrealized_plpc;
+    obj["unrealized_intraday_pl"]   = pos.unrealized_intraday_pl;
+    obj["unrealized_intraday_plpc"] = pos.unrealized_intraday_plpc;
+    obj["current_price"]            = pos.current_price;
+    obj["lastday_price"]            = pos.lastday_price;
+    obj["change_today"]             = pos.change_today;
+    obj["asset_marginable"]         = pos.asset_marginable;
 
     if (pos.qty_available.has_value())
-        j["qty_available"] = pos.qty_available.value();
+        obj["qty_available"] = pos.qty_available.value();
+
+    jv = std::move(obj);
 }
 
 //
 // orders.hpp JSON serialization implementations
+//
 
-void to_json(nlohmann::json& j, const order_side& side)
+void tag_invoke(json::value_from_tag, json::value& jv, const order_side& side)
 {
     switch (side)
     {
         case order_side::BUY:
-            j = "buy";
+            jv = "buy";
             break;
         case order_side::SELL:
-            j = "sell";
+            jv = "sell";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, order_side& side)
+order_side tag_invoke(json::value_to_tag<order_side>, const json::value& jv)
 {
-    if (const std::string side_str = j; side_str == "buy")
-    {
-        side = order_side::BUY;
-    }
-    else if (side_str == "sell")
-    {
-        side = order_side::SELL;
-    }
-    else
-    {
-        throw std::invalid_argument("Invalid order_side: " + side_str);
-    }
+    const std::string side_str = json::value_to<std::string>(jv);
+    if (side_str == "buy")
+        return order_side::BUY;
+    if (side_str == "sell")
+        return order_side::SELL;
+    throw std::invalid_argument("Invalid order_side: " + side_str);
 }
 
-void to_json(nlohmann::json& j, const order_class& oc)
+void tag_invoke(json::value_from_tag, json::value& jv, const order_class& oc)
 {
     switch (oc)
     {
         case order_class::SIMPLE:
-            j = "simple";
+            jv = "simple";
             break;
         case order_class::BRACKET:
-            j = "bracket";
+            jv = "bracket";
             break;
         case order_class::OCO:
-            j = "oco";
+            jv = "oco";
             break;
         case order_class::OTO:
-            j = "oto";
+            jv = "oto";
             break;
         case order_class::MLEG:
-            j = "mleg";
+            jv = "mleg";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, order_class& oc)
+order_class tag_invoke(json::value_to_tag<order_class>, const json::value& jv)
 {
-    if (const std::string class_str = j; class_str == "simple" || class_str.empty())
-        oc = order_class::SIMPLE;
-    else if (class_str == "bracket")
-        oc = order_class::BRACKET;
-    else if (class_str == "oco")
-        oc = order_class::OCO;
-    else if (class_str == "oto")
-        oc = order_class::OTO;
-    else if (class_str == "mleg")
-        oc = order_class::MLEG;
-    else
-        throw std::invalid_argument("Invalid order_class: " + class_str);
+    const std::string class_str = json::value_to<std::string>(jv);
+    if (class_str == "simple" || class_str.empty())
+        return order_class::SIMPLE;
+    if (class_str == "bracket")
+        return order_class::BRACKET;
+    if (class_str == "oco")
+        return order_class::OCO;
+    if (class_str == "oto")
+        return order_class::OTO;
+    if (class_str == "mleg")
+        return order_class::MLEG;
+    throw std::invalid_argument("Invalid order_class: " + class_str);
 }
 
-void to_json(nlohmann::json& j, const order_type& ot)
+void tag_invoke(json::value_from_tag, json::value& jv, const order_type& ot)
 {
     switch (ot)
     {
         case order_type::MARKET:
-            j = "market";
+            jv = "market";
             break;
         case order_type::LIMIT:
-            j = "limit";
+            jv = "limit";
             break;
         case order_type::STOP:
-            j = "stop";
+            jv = "stop";
             break;
         case order_type::STOP_LIMIT:
-            j = "stop_limit";
+            jv = "stop_limit";
             break;
         case order_type::TRAILING_STOP:
-            j = "trailing_stop";
+            jv = "trailing_stop";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, order_type& ot)
+order_type tag_invoke(json::value_to_tag<order_type>, const json::value& jv)
 {
-    if (const std::string type_str = j; type_str == "market")
-        ot = order_type::MARKET;
-    else if (type_str == "limit")
-        ot = order_type::LIMIT;
-    else if (type_str == "stop")
-        ot = order_type::STOP;
-    else if (type_str == "stop_limit")
-        ot = order_type::STOP_LIMIT;
-    else if (type_str == "trailing_stop")
-        ot = order_type::TRAILING_STOP;
-    else
-        throw std::invalid_argument("Invalid order_type: " + type_str);
+    const std::string type_str = json::value_to<std::string>(jv);
+    if (type_str == "market")
+        return order_type::MARKET;
+    if (type_str == "limit")
+        return order_type::LIMIT;
+    if (type_str == "stop")
+        return order_type::STOP;
+    if (type_str == "stop_limit")
+        return order_type::STOP_LIMIT;
+    if (type_str == "trailing_stop")
+        return order_type::TRAILING_STOP;
+    throw std::invalid_argument("Invalid order_type: " + type_str);
 }
 
-void to_json(nlohmann::json& j, const time_in_force& tif)
+void tag_invoke(json::value_from_tag, json::value& jv, const time_in_force& tif)
 {
     switch (tif)
     {
         case time_in_force::DAY:
-            j = "day";
+            jv = "day";
             break;
         case time_in_force::GTC:
-            j = "gtc";
+            jv = "gtc";
             break;
         case time_in_force::OPG:
-            j = "opg";
+            jv = "opg";
             break;
         case time_in_force::CLS:
-            j = "cls";
+            jv = "cls";
             break;
         case time_in_force::IOC:
-            j = "ioc";
+            jv = "ioc";
             break;
         case time_in_force::FOK:
-            j = "fok";
+            jv = "fok";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, time_in_force& tif)
+time_in_force tag_invoke(json::value_to_tag<time_in_force>, const json::value& jv)
 {
-    if (const std::string tif_str = j; tif_str == "day")
-        tif = time_in_force::DAY;
-    else if (tif_str == "gtc")
-        tif = time_in_force::GTC;
-    else if (tif_str == "opg")
-        tif = time_in_force::OPG;
-    else if (tif_str == "cls")
-        tif = time_in_force::CLS;
-    else if (tif_str == "ioc")
-        tif = time_in_force::IOC;
-    else if (tif_str == "fok")
-        tif = time_in_force::FOK;
-    else
-        throw std::invalid_argument("Invalid time_in_force: " + tif_str);
+    const std::string tif_str = json::value_to<std::string>(jv);
+    if (tif_str == "day")
+        return time_in_force::DAY;
+    if (tif_str == "gtc")
+        return time_in_force::GTC;
+    if (tif_str == "opg")
+        return time_in_force::OPG;
+    if (tif_str == "cls")
+        return time_in_force::CLS;
+    if (tif_str == "ioc")
+        return time_in_force::IOC;
+    if (tif_str == "fok")
+        return time_in_force::FOK;
+    throw std::invalid_argument("Invalid time_in_force: " + tif_str);
 }
 
-void to_json(nlohmann::json& j, const order_status& os)
+void tag_invoke(json::value_from_tag, json::value& jv, const order_status& os)
 {
     switch (os)
     {
         case order_status::NEW:
-            j = "new";
+            jv = "new";
             break;
         case order_status::PARTIALLY_FILLED:
-            j = "partially_filled";
+            jv = "partially_filled";
             break;
         case order_status::FILLED:
-            j = "filled";
+            jv = "filled";
             break;
         case order_status::DONE_FOR_DAY:
-            j = "done_for_day";
+            jv = "done_for_day";
             break;
         case order_status::CANCELED:
-            j = "canceled";
+            jv = "canceled";
             break;
         case order_status::EXPIRED:
-            j = "expired";
+            jv = "expired";
             break;
         case order_status::REPLACED:
-            j = "replaced";
+            jv = "replaced";
             break;
         case order_status::PENDING_CANCEL:
-            j = "pending_cancel";
+            jv = "pending_cancel";
             break;
         case order_status::PENDING_REPLACE:
-            j = "pending_replace";
+            jv = "pending_replace";
             break;
         case order_status::ACCEPTED:
-            j = "accepted";
+            jv = "accepted";
             break;
         case order_status::PENDING_NEW:
-            j = "pending_new";
+            jv = "pending_new";
             break;
         case order_status::ACCEPTED_FOR_BIDDING:
-            j = "accepted_for_bidding";
+            jv = "accepted_for_bidding";
             break;
         case order_status::STOPPED:
-            j = "stopped";
+            jv = "stopped";
             break;
         case order_status::REJECTED:
-            j = "rejected";
+            jv = "rejected";
             break;
         case order_status::SUSPENDED:
-            j = "suspended";
+            jv = "suspended";
             break;
         case order_status::CALCULATED:
-            j = "calculated";
+            jv = "calculated";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, order_status& os)
+order_status tag_invoke(json::value_to_tag<order_status>, const json::value& jv)
 {
-    if (const std::string status_str = j; status_str == "new")
-        os = order_status::NEW;
-    else if (status_str == "partially_filled")
-        os = order_status::PARTIALLY_FILLED;
-    else if (status_str == "filled")
-        os = order_status::FILLED;
-    else if (status_str == "done_for_day")
-        os = order_status::DONE_FOR_DAY;
-    else if (status_str == "canceled")
-        os = order_status::CANCELED;
-    else if (status_str == "expired")
-        os = order_status::EXPIRED;
-    else if (status_str == "replaced")
-        os = order_status::REPLACED;
-    else if (status_str == "pending_cancel")
-        os = order_status::PENDING_CANCEL;
-    else if (status_str == "pending_replace")
-        os = order_status::PENDING_REPLACE;
-    else if (status_str == "accepted")
-        os = order_status::ACCEPTED;
-    else if (status_str == "pending_new")
-        os = order_status::PENDING_NEW;
-    else if (status_str == "accepted_for_bidding")
-        os = order_status::ACCEPTED_FOR_BIDDING;
-    else if (status_str == "stopped")
-        os = order_status::STOPPED;
-    else if (status_str == "rejected")
-        os = order_status::REJECTED;
-    else if (status_str == "suspended")
-        os = order_status::SUSPENDED;
-    else if (status_str == "calculated")
-        os = order_status::CALCULATED;
-    else
-        throw std::invalid_argument("Invalid order_status: " + status_str);
+    const std::string status_str = json::value_to<std::string>(jv);
+    if (status_str == "new")
+        return order_status::NEW;
+    if (status_str == "partially_filled")
+        return order_status::PARTIALLY_FILLED;
+    if (status_str == "filled")
+        return order_status::FILLED;
+    if (status_str == "done_for_day")
+        return order_status::DONE_FOR_DAY;
+    if (status_str == "canceled")
+        return order_status::CANCELED;
+    if (status_str == "expired")
+        return order_status::EXPIRED;
+    if (status_str == "replaced")
+        return order_status::REPLACED;
+    if (status_str == "pending_cancel")
+        return order_status::PENDING_CANCEL;
+    if (status_str == "pending_replace")
+        return order_status::PENDING_REPLACE;
+    if (status_str == "accepted")
+        return order_status::ACCEPTED;
+    if (status_str == "pending_new")
+        return order_status::PENDING_NEW;
+    if (status_str == "accepted_for_bidding")
+        return order_status::ACCEPTED_FOR_BIDDING;
+    if (status_str == "stopped")
+        return order_status::STOPPED;
+    if (status_str == "rejected")
+        return order_status::REJECTED;
+    if (status_str == "suspended")
+        return order_status::SUSPENDED;
+    if (status_str == "calculated")
+        return order_status::CALCULATED;
+    throw std::invalid_argument("Invalid order_status: " + status_str);
 }
 
-void to_json(nlohmann::json& j, const position_intent& pi)
+void tag_invoke(json::value_from_tag, json::value& jv, const position_intent& pi)
 {
     switch (pi)
     {
         case position_intent::BUY_TO_OPEN:
-            j = "buy_to_open";
+            jv = "buy_to_open";
             break;
         case position_intent::BUY_TO_CLOSE:
-            j = "buy_to_close";
+            jv = "buy_to_close";
             break;
         case position_intent::SELL_TO_OPEN:
-            j = "sell_to_open";
+            jv = "sell_to_open";
             break;
         case position_intent::SELL_TO_CLOSE:
-            j = "sell_to_close";
+            jv = "sell_to_close";
             break;
     }
 }
 
-void from_json(const nlohmann::json& j, position_intent& pi)
+position_intent tag_invoke(json::value_to_tag<position_intent>, const json::value& jv)
 {
-    if (const std::string intent_str = j; intent_str == "buy_to_open")
-        pi = position_intent::BUY_TO_OPEN;
-    else if (intent_str == "buy_to_close")
-        pi = position_intent::BUY_TO_CLOSE;
-    else if (intent_str == "sell_to_open")
-        pi = position_intent::SELL_TO_OPEN;
-    else if (intent_str == "sell_to_close")
-        pi = position_intent::SELL_TO_CLOSE;
-    else
-        throw std::invalid_argument("Invalid position_intent: " + intent_str);
+    const std::string intent_str = json::value_to<std::string>(jv);
+    if (intent_str == "buy_to_open")
+        return position_intent::BUY_TO_OPEN;
+    if (intent_str == "buy_to_close")
+        return position_intent::BUY_TO_CLOSE;
+    if (intent_str == "sell_to_open")
+        return position_intent::SELL_TO_OPEN;
+    if (intent_str == "sell_to_close")
+        return position_intent::SELL_TO_CLOSE;
+    throw std::invalid_argument("Invalid position_intent: " + intent_str);
 }
 
-void from_json(const nlohmann::json& j, order& o)
+order tag_invoke(json::value_to_tag<order>, const json::value& jv)
 {
-    j.at("id").get_to(o.id);
-    j.at("client_order_id").get_to(o.client_order_id);
-    j.at("created_at").get_to(o.created_at);
-    j.at("asset_id").get_to(o.asset_id);
-    j.at("symbol").get_to(o.symbol);
-    j.at("asset_class").get_to(o.asset_class_type);
-    j.at("filled_qty").get_to(o.filled_qty);
-    j.at("order_class").get_to(o.order_class_type);
-    j.at("order_type").get_to(o.type);
-    j.at("side").get_to(o.side);
-    j.at("time_in_force").get_to(o.time_in_force_type);
-    j.at("status").get_to(o.status);
-    j.at("extended_hours").get_to(o.extended_hours);
+    const auto& obj = jv.as_object();
+    order       o;
 
-    if (j.contains("updated_at") && !j.at("updated_at").is_null())
-        o.updated_at = j.at("updated_at").get<std::string>();
-    if (j.contains("submitted_at") && !j.at("submitted_at").is_null())
-        o.submitted_at = j.at("submitted_at").get<std::string>();
-    if (j.contains("filled_at") && !j.at("filled_at").is_null())
-        o.filled_at = j.at("filled_at").get<std::string>();
-    if (j.contains("expired_at") && !j.at("expired_at").is_null())
-        o.expired_at = j.at("expired_at").get<std::string>();
-    if (j.contains("canceled_at") && !j.at("canceled_at").is_null())
-        o.canceled_at = j.at("canceled_at").get<std::string>();
-    if (j.contains("failed_at") && !j.at("failed_at").is_null())
-        o.failed_at = j.at("failed_at").get<std::string>();
-    if (j.contains("replaced_at") && !j.at("replaced_at").is_null())
-        o.replaced_at = j.at("replaced_at").get<std::string>();
-    if (j.contains("replaced_by") && !j.at("replaced_by").is_null())
-        o.replaced_by = j.at("replaced_by").get<std::string>();
-    if (j.contains("replaces") && !j.at("replaces").is_null())
-        o.replaces = j.at("replaces").get<std::string>();
-    if (j.contains("notional") && !j.at("notional").is_null())
-        o.notional = j.at("notional").get<std::string>();
-    if (j.contains("qty") && !j.at("qty").is_null())
-        o.qty = j.at("qty").get<std::string>();
-    if (j.contains("filled_avg_price") && !j.at("filled_avg_price").is_null())
-        o.filled_avg_price = j.at("filled_avg_price").get<std::string>();
-    if (j.contains("limit_price") && !j.at("limit_price").is_null())
-        o.limit_price = j.at("limit_price").get<std::string>();
-    if (j.contains("stop_price") && !j.at("stop_price").is_null())
-        o.stop_price = j.at("stop_price").get<std::string>();
-    if (j.contains("trail_percent") && !j.at("trail_percent").is_null())
-        o.trail_percent = j.at("trail_percent").get<std::string>();
-    if (j.contains("trail_price") && !j.at("trail_price").is_null())
-        o.trail_price = j.at("trail_price").get<std::string>();
-    if (j.contains("hwm") && !j.at("hwm").is_null())
-        o.hwm = j.at("hwm").get<std::string>();
-    if (j.contains("position_intent") && !j.at("position_intent").is_null())
-        o.position_intent_type = j.at("position_intent").get<position_intent>();
-    if (j.contains("legs") && !j.at("legs").is_null())
-        o.legs = j.at("legs").get<std::vector<order>>();
+    o.id                 = json::value_to<std::string>(obj.at("id"));
+    o.client_order_id    = json::value_to<std::string>(obj.at("client_order_id"));
+    o.created_at         = json::value_to<std::string>(obj.at("created_at"));
+    o.asset_id           = json::value_to<std::string>(obj.at("asset_id"));
+    o.symbol             = json::value_to<std::string>(obj.at("symbol"));
+    o.asset_class_type   = json::value_to<asset_class>(obj.at("asset_class"));
+    o.filled_qty         = json::value_to<std::string>(obj.at("filled_qty"));
+    o.order_class_type   = json::value_to<order_class>(obj.at("order_class"));
+    o.type               = json::value_to<order_type>(obj.at("order_type"));
+    o.side               = json::value_to<order_side>(obj.at("side"));
+    o.time_in_force_type = json::value_to<time_in_force>(obj.at("time_in_force"));
+    o.status             = json::value_to<order_status>(obj.at("status"));
+    o.extended_hours     = json::value_to<bool>(obj.at("extended_hours"));
+
+    if (obj.contains("updated_at") && !obj.at("updated_at").is_null())
+        o.updated_at = json::value_to<std::string>(obj.at("updated_at"));
+    if (obj.contains("submitted_at") && !obj.at("submitted_at").is_null())
+        o.submitted_at = json::value_to<std::string>(obj.at("submitted_at"));
+    if (obj.contains("filled_at") && !obj.at("filled_at").is_null())
+        o.filled_at = json::value_to<std::string>(obj.at("filled_at"));
+    if (obj.contains("expired_at") && !obj.at("expired_at").is_null())
+        o.expired_at = json::value_to<std::string>(obj.at("expired_at"));
+    if (obj.contains("canceled_at") && !obj.at("canceled_at").is_null())
+        o.canceled_at = json::value_to<std::string>(obj.at("canceled_at"));
+    if (obj.contains("failed_at") && !obj.at("failed_at").is_null())
+        o.failed_at = json::value_to<std::string>(obj.at("failed_at"));
+    if (obj.contains("replaced_at") && !obj.at("replaced_at").is_null())
+        o.replaced_at = json::value_to<std::string>(obj.at("replaced_at"));
+    if (obj.contains("replaced_by") && !obj.at("replaced_by").is_null())
+        o.replaced_by = json::value_to<std::string>(obj.at("replaced_by"));
+    if (obj.contains("replaces") && !obj.at("replaces").is_null())
+        o.replaces = json::value_to<std::string>(obj.at("replaces"));
+    if (obj.contains("notional") && !obj.at("notional").is_null())
+        o.notional = json::value_to<std::string>(obj.at("notional"));
+    if (obj.contains("qty") && !obj.at("qty").is_null())
+        o.qty = json::value_to<std::string>(obj.at("qty"));
+    if (obj.contains("filled_avg_price") && !obj.at("filled_avg_price").is_null())
+        o.filled_avg_price = json::value_to<std::string>(obj.at("filled_avg_price"));
+    if (obj.contains("limit_price") && !obj.at("limit_price").is_null())
+        o.limit_price = json::value_to<std::string>(obj.at("limit_price"));
+    if (obj.contains("stop_price") && !obj.at("stop_price").is_null())
+        o.stop_price = json::value_to<std::string>(obj.at("stop_price"));
+    if (obj.contains("trail_percent") && !obj.at("trail_percent").is_null())
+        o.trail_percent = json::value_to<std::string>(obj.at("trail_percent"));
+    if (obj.contains("trail_price") && !obj.at("trail_price").is_null())
+        o.trail_price = json::value_to<std::string>(obj.at("trail_price"));
+    if (obj.contains("hwm") && !obj.at("hwm").is_null())
+        o.hwm = json::value_to<std::string>(obj.at("hwm"));
+    if (obj.contains("position_intent") && !obj.at("position_intent").is_null())
+        o.position_intent_type = json::value_to<position_intent>(obj.at("position_intent"));
+    if (obj.contains("legs") && !obj.at("legs").is_null())
+        o.legs = json::value_to<std::vector<order>>(obj.at("legs"));
+
+    return o;
 }
 
-void to_json(nlohmann::json& j, const order& o)
+void tag_invoke(json::value_from_tag, json::value& jv, const order& o)
 {
-    j = nlohmann::json{
-        {"id", o.id},
-        {"client_order_id", o.client_order_id},
-        {"created_at", o.created_at},
-        {"asset_id", o.asset_id},
-        {"symbol", o.symbol},
-        {"asset_class", o.asset_class_type},
-        {"filled_qty", o.filled_qty},
-        {"order_class", o.order_class_type},
-        {"order_type", o.type},
-        {"side", o.side},
-        {"time_in_force", o.time_in_force_type},
-        {"status", o.status},
-        {"extended_hours", o.extended_hours}};
+    json::object obj;
+    obj["id"]              = o.id;
+    obj["client_order_id"] = o.client_order_id;
+    obj["created_at"]      = o.created_at;
+    obj["asset_id"]        = o.asset_id;
+    obj["symbol"]          = o.symbol;
+    obj["asset_class"]     = json::value_from(o.asset_class_type);
+    obj["filled_qty"]      = o.filled_qty;
+    obj["order_class"]     = json::value_from(o.order_class_type);
+    obj["order_type"]      = json::value_from(o.type);
+    obj["side"]            = json::value_from(o.side);
+    obj["time_in_force"]   = json::value_from(o.time_in_force_type);
+    obj["status"]          = json::value_from(o.status);
+    obj["extended_hours"]  = o.extended_hours;
 
     if (o.updated_at.has_value())
-        j["updated_at"] = o.updated_at.value();
+        obj["updated_at"] = o.updated_at.value();
     if (o.submitted_at.has_value())
-        j["submitted_at"] = o.submitted_at.value();
+        obj["submitted_at"] = o.submitted_at.value();
     if (o.filled_at.has_value())
-        j["filled_at"] = o.filled_at.value();
+        obj["filled_at"] = o.filled_at.value();
     if (o.expired_at.has_value())
-        j["expired_at"] = o.expired_at.value();
+        obj["expired_at"] = o.expired_at.value();
     if (o.canceled_at.has_value())
-        j["canceled_at"] = o.canceled_at.value();
+        obj["canceled_at"] = o.canceled_at.value();
     if (o.failed_at.has_value())
-        j["failed_at"] = o.failed_at.value();
+        obj["failed_at"] = o.failed_at.value();
     if (o.replaced_at.has_value())
-        j["replaced_at"] = o.replaced_at.value();
+        obj["replaced_at"] = o.replaced_at.value();
     if (o.replaced_by.has_value())
-        j["replaced_by"] = o.replaced_by.value();
+        obj["replaced_by"] = o.replaced_by.value();
     if (o.replaces.has_value())
-        j["replaces"] = o.replaces.value();
+        obj["replaces"] = o.replaces.value();
     if (o.notional.has_value())
-        j["notional"] = o.notional.value();
+        obj["notional"] = o.notional.value();
     if (o.qty.has_value())
-        j["qty"] = o.qty.value();
+        obj["qty"] = o.qty.value();
     if (o.filled_avg_price.has_value())
-        j["filled_avg_price"] = o.filled_avg_price.value();
+        obj["filled_avg_price"] = o.filled_avg_price.value();
     if (o.limit_price.has_value())
-        j["limit_price"] = o.limit_price.value();
+        obj["limit_price"] = o.limit_price.value();
     if (o.stop_price.has_value())
-        j["stop_price"] = o.stop_price.value();
+        obj["stop_price"] = o.stop_price.value();
     if (o.trail_percent.has_value())
-        j["trail_percent"] = o.trail_percent.value();
+        obj["trail_percent"] = o.trail_percent.value();
     if (o.trail_price.has_value())
-        j["trail_price"] = o.trail_price.value();
+        obj["trail_price"] = o.trail_price.value();
     if (o.hwm.has_value())
-        j["hwm"] = o.hwm.value();
+        obj["hwm"] = o.hwm.value();
     if (o.position_intent_type.has_value())
-        j["position_intent"] = o.position_intent_type.value();
+        obj["position_intent"] = json::value_from(o.position_intent_type.value());
     if (o.legs.has_value())
-        j["legs"] = o.legs.value();
+        obj["legs"] = json::value_from(o.legs.value());
+
+    jv = std::move(obj);
 }
 
-void to_json(nlohmann::json& j, const notional_order& order)
+void tag_invoke(json::value_from_tag, json::value& jv, const notional_order& order)
 {
-    j = nlohmann::json{
-        {"symbol", order.symbol},
-        {"notional", order.notional},
-        {"side", order.side},
-        {"type", "market"},
-        {"time_in_force", "day"},
-        {"extended_hours", order.extended_hours}};
+    json::object obj;
+    obj["symbol"]         = order.symbol;
+    obj["notional"]       = order.notional;
+    obj["side"]           = json::value_from(order.side);
+    obj["type"]           = "market";
+    obj["time_in_force"]  = "day";
+    obj["extended_hours"] = order.extended_hours;
 
     if (!order.client_order_id.empty())
-    {
-        j["client_order_id"] = order.client_order_id;
-    }
+        obj["client_order_id"] = order.client_order_id;
+
+    jv = std::move(obj);
 }
 
-void from_json(const nlohmann::json& j, notional_order& order)
+notional_order tag_invoke(json::value_to_tag<notional_order>, const json::value& jv)
 {
-    j.at("symbol").get_to(order.symbol);
-    j.at("notional").get_to(order.notional);
-    j.at("side").get_to(order.side);
-    j.at("extended_hours").get_to(order.extended_hours);
+    const auto&    obj = jv.as_object();
+    notional_order order;
 
-    if (j.contains("client_order_id"))
-    {
-        j.at("client_order_id").get_to(order.client_order_id);
-    }
+    order.symbol         = json::value_to<std::string>(obj.at("symbol"));
+    order.notional       = json::value_to<std::string>(obj.at("notional"));
+    order.side           = json::value_to<order_side>(obj.at("side"));
+    order.extended_hours = json::value_to<bool>(obj.at("extended_hours"));
+
+    if (obj.contains("client_order_id"))
+        order.client_order_id = json::value_to<std::string>(obj.at("client_order_id"));
+
+    return order;
 }
 
-void from_json(const nlohmann::json& j, position_closed& pc)
+position_closed tag_invoke(json::value_to_tag<position_closed>, const json::value& jv)
 {
-    j.at("symbol").get_to(pc.symbol);
-    j.at("status").get_to(pc.status);
-    j.at("body").get_to(pc.order_details);
+    const auto&     obj = jv.as_object();
+    position_closed pc;
+
+    pc.symbol        = json::value_to<std::string>(obj.at("symbol"));
+    pc.status        = json::value_to<int>(obj.at("status"));
+    pc.order_details = json::value_to<order>(obj.at("body"));
+
+    return pc;
 }
 
-void to_json(nlohmann::json& j, const position_closed& pc)
+void tag_invoke(json::value_from_tag, json::value& jv, const position_closed& pc)
 {
-    j = nlohmann::json{{"symbol", pc.symbol}, {"status", pc.status}, {"body", pc.order_details}};
+    json::object obj;
+    obj["symbol"] = pc.symbol;
+    obj["status"] = pc.status;
+    obj["body"]   = json::value_from(pc.order_details);
+
+    jv = std::move(obj);
 }
 
-void from_json(const nlohmann::json& j, order_deleted& od)
+order_deleted tag_invoke(json::value_to_tag<order_deleted>, const json::value& jv)
 {
-    j.at("id").get_to(od.id);
-    j.at("status").get_to(od.status);
+    const auto&   obj = jv.as_object();
+    order_deleted od;
+
+    od.id     = json::value_to<std::string>(obj.at("id"));
+    od.status = json::value_to<int>(obj.at("status"));
+
+    return od;
 }
 
-void to_json(nlohmann::json& j, const order_deleted& od)
+void tag_invoke(json::value_from_tag, json::value& jv, const order_deleted& od)
 {
-    j = nlohmann::json{{"id", od.id}, {"status", od.status}};
+    json::object obj;
+    obj["id"]     = od.id;
+    obj["status"] = od.status;
+
+    jv = std::move(obj);
 }

--- a/alpaca_trade_client/src/json_utils.cpp
+++ b/alpaca_trade_client/src/json_utils.cpp
@@ -1,4 +1,5 @@
 #include "alpaca_trade_client/account.hpp"
+#include "alpaca_trade_client/enum_serialization.hpp"
 #include "alpaca_trade_client/orders.hpp"
 #include "alpaca_trade_client/position.hpp"
 
@@ -10,120 +11,12 @@ namespace json = boost::json;
 
 void tag_invoke(json::value_from_tag, json::value& jv, const account_status& status)
 {
-    switch (status)
-    {
-        case account_status::ACCOUNT_CLOSED:
-            jv = "ACCOUNT_CLOSED";
-            break;
-        case account_status::ACCOUNT_UPDATED:
-            jv = "ACCOUNT_UPDATED";
-            break;
-        case account_status::ACTION_REQUIRED:
-            jv = "ACTION_REQUIRED";
-            break;
-        case account_status::ACTIVE:
-            jv = "ACTIVE";
-            break;
-        case account_status::AML_REVIEW:
-            jv = "AML_REVIEW";
-            break;
-        case account_status::APPROVAL_PENDING:
-            jv = "APPROVAL_PENDING";
-            break;
-        case account_status::APPROVED:
-            jv = "APPROVED";
-            break;
-        case account_status::DISABLED:
-            jv = "DISABLED";
-            break;
-        case account_status::DISABLE_PENDING:
-            jv = "DISABLE_PENDING";
-            break;
-        case account_status::EDITED:
-            jv = "EDITED";
-            break;
-        case account_status::INACTIVE:
-            jv = "INACTIVE";
-            break;
-        case account_status::KYC_SUBMITTED:
-            jv = "KYC_SUBMITTED";
-            break;
-        case account_status::LIMITED:
-            jv = "LIMITED";
-            break;
-        case account_status::ONBOARDING:
-            jv = "ONBOARDING";
-            break;
-        case account_status::PAPER_ONLY:
-            jv = "PAPER_ONLY";
-            break;
-        case account_status::REAPPROVAL_PENDING:
-            jv = "REAPPROVAL_PENDING";
-            break;
-        case account_status::REJECTED:
-            jv = "REJECTED";
-            break;
-        case account_status::RESUBMITTED:
-            jv = "RESUBMITTED";
-            break;
-        case account_status::SIGNED_UP:
-            jv = "SIGNED_UP";
-            break;
-        case account_status::SUBMISSION_FAILED:
-            jv = "SUBMISSION_FAILED";
-            break;
-        case account_status::SUBMITTED:
-            jv = "SUBMITTED";
-            break;
-    }
+    enum_value_from_tag(jv, status);
 }
 
 account_status tag_invoke(json::value_to_tag<account_status>, const json::value& jv)
 {
-    const std::string status_str = json::value_to<std::string>(jv);
-    if (status_str == "ACCOUNT_CLOSED")
-        return account_status::ACCOUNT_CLOSED;
-    if (status_str == "ACCOUNT_UPDATED")
-        return account_status::ACCOUNT_UPDATED;
-    if (status_str == "ACTION_REQUIRED")
-        return account_status::ACTION_REQUIRED;
-    if (status_str == "ACTIVE")
-        return account_status::ACTIVE;
-    if (status_str == "AML_REVIEW")
-        return account_status::AML_REVIEW;
-    if (status_str == "APPROVAL_PENDING")
-        return account_status::APPROVAL_PENDING;
-    if (status_str == "APPROVED")
-        return account_status::APPROVED;
-    if (status_str == "DISABLED")
-        return account_status::DISABLED;
-    if (status_str == "DISABLE_PENDING")
-        return account_status::DISABLE_PENDING;
-    if (status_str == "EDITED")
-        return account_status::EDITED;
-    if (status_str == "INACTIVE")
-        return account_status::INACTIVE;
-    if (status_str == "KYC_SUBMITTED")
-        return account_status::KYC_SUBMITTED;
-    if (status_str == "LIMITED")
-        return account_status::LIMITED;
-    if (status_str == "ONBOARDING")
-        return account_status::ONBOARDING;
-    if (status_str == "PAPER_ONLY")
-        return account_status::PAPER_ONLY;
-    if (status_str == "REAPPROVAL_PENDING")
-        return account_status::REAPPROVAL_PENDING;
-    if (status_str == "REJECTED")
-        return account_status::REJECTED;
-    if (status_str == "RESUBMITTED")
-        return account_status::RESUBMITTED;
-    if (status_str == "SIGNED_UP")
-        return account_status::SIGNED_UP;
-    if (status_str == "SUBMISSION_FAILED")
-        return account_status::SUBMISSION_FAILED;
-    if (status_str == "SUBMITTED")
-        return account_status::SUBMITTED;
-    throw std::invalid_argument("Invalid account_status: " + status_str);
+    return enum_value_to_tag<account_status>(jv);
 }
 
 trade_account tag_invoke(json::value_to_tag<trade_account>, const json::value& jv)
@@ -288,131 +181,32 @@ void tag_invoke(json::value_from_tag, json::value& jv, const trade_account& acco
 
 void tag_invoke(json::value_from_tag, json::value& jv, const asset_exchange& exchange)
 {
-    switch (exchange)
-    {
-        case asset_exchange::AMEX:
-            jv = "AMEX";
-            break;
-        case asset_exchange::ARCA:
-            jv = "ARCA";
-            break;
-        case asset_exchange::BATS:
-            jv = "BATS";
-            break;
-        case asset_exchange::NYSE:
-            jv = "NYSE";
-            break;
-        case asset_exchange::NASDAQ:
-            jv = "NASDAQ";
-            break;
-        case asset_exchange::NYSEARCA:
-            jv = "NYSEARCA";
-            break;
-        case asset_exchange::OTC:
-            jv = "OTC";
-            break;
-        case asset_exchange::FTXU:
-            jv = "FTXU";
-            break;
-        case asset_exchange::CBSE:
-            jv = "CBSE";
-            break;
-        case asset_exchange::GNSS:
-            jv = "GNSS";
-            break;
-        case asset_exchange::ERSX:
-            jv = "ERSX";
-            break;
-        case asset_exchange::CRYPTO:
-            jv = "CRYPTO";
-            break;
-        case asset_exchange::EMPTY:
-            jv = "";
-            break;
-    }
+    enum_value_from_tag(jv, exchange);
 }
 
 asset_exchange tag_invoke(json::value_to_tag<asset_exchange>, const json::value& jv)
 {
-    const std::string exchange_str = json::value_to<std::string>(jv);
-    if (exchange_str == "AMEX")
-        return asset_exchange::AMEX;
-    if (exchange_str == "ARCA")
-        return asset_exchange::ARCA;
-    if (exchange_str == "BATS")
-        return asset_exchange::BATS;
-    if (exchange_str == "NYSE")
-        return asset_exchange::NYSE;
-    if (exchange_str == "NASDAQ")
-        return asset_exchange::NASDAQ;
-    if (exchange_str == "NYSEARCA")
-        return asset_exchange::NYSEARCA;
-    if (exchange_str == "OTC")
-        return asset_exchange::OTC;
-    if (exchange_str == "FTXU")
-        return asset_exchange::FTXU;
-    if (exchange_str == "CBSE")
-        return asset_exchange::CBSE;
-    if (exchange_str == "GNSS")
-        return asset_exchange::GNSS;
-    if (exchange_str == "ERSX")
-        return asset_exchange::ERSX;
-    if (exchange_str == "CRYPTO")
-        return asset_exchange::CRYPTO;
-    if (exchange_str == "")
-        return asset_exchange::EMPTY;
-    throw std::invalid_argument("Invalid asset_exchange: " + exchange_str);
+    return enum_value_to_tag<asset_exchange>(jv);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const asset_class& asset_class_type)
 {
-    switch (asset_class_type)
-    {
-        case asset_class::US_EQUITY:
-            jv = "us_equity";
-            break;
-        case asset_class::US_OPTION:
-            jv = "us_option";
-            break;
-        case asset_class::CRYPTO:
-            jv = "crypto";
-            break;
-    }
+    enum_value_from_tag(jv, asset_class_type);
 }
 
 asset_class tag_invoke(json::value_to_tag<asset_class>, const json::value& jv)
 {
-    const std::string class_str = json::value_to<std::string>(jv);
-    if (class_str == "us_equity")
-        return asset_class::US_EQUITY;
-    if (class_str == "us_option")
-        return asset_class::US_OPTION;
-    if (class_str == "crypto")
-        return asset_class::CRYPTO;
-    throw std::invalid_argument("Invalid asset_class: " + class_str);
+    return enum_value_to_tag<asset_class>(jv);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const position_side& side)
 {
-    switch (side)
-    {
-        case position_side::LONG:
-            jv = "long";
-            break;
-        case position_side::SHORT:
-            jv = "short";
-            break;
-    }
+    enum_value_from_tag(jv, side);
 }
 
 position_side tag_invoke(json::value_to_tag<position_side>, const json::value& jv)
 {
-    const std::string side_str = json::value_to<std::string>(jv);
-    if (side_str == "long")
-        return position_side::LONG;
-    if (side_str == "short")
-        return position_side::SHORT;
-    throw std::invalid_argument("Invalid position_side: " + side_str);
+    return enum_value_to_tag<position_side>(jv);
 }
 
 position tag_invoke(json::value_to_tag<position>, const json::value& jv)
@@ -477,270 +271,62 @@ void tag_invoke(json::value_from_tag, json::value& jv, const position& pos)
 
 void tag_invoke(json::value_from_tag, json::value& jv, const order_side& side)
 {
-    switch (side)
-    {
-        case order_side::BUY:
-            jv = "buy";
-            break;
-        case order_side::SELL:
-            jv = "sell";
-            break;
-    }
+    enum_value_from_tag(jv, side);
 }
 
 order_side tag_invoke(json::value_to_tag<order_side>, const json::value& jv)
 {
-    const std::string side_str = json::value_to<std::string>(jv);
-    if (side_str == "buy")
-        return order_side::BUY;
-    if (side_str == "sell")
-        return order_side::SELL;
-    throw std::invalid_argument("Invalid order_side: " + side_str);
+    return enum_value_to_tag<order_side>(jv);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const order_class& oc)
 {
-    switch (oc)
-    {
-        case order_class::SIMPLE:
-            jv = "simple";
-            break;
-        case order_class::BRACKET:
-            jv = "bracket";
-            break;
-        case order_class::OCO:
-            jv = "oco";
-            break;
-        case order_class::OTO:
-            jv = "oto";
-            break;
-        case order_class::MLEG:
-            jv = "mleg";
-            break;
-    }
+    enum_value_from_tag(jv, oc);
 }
 
 order_class tag_invoke(json::value_to_tag<order_class>, const json::value& jv)
 {
-    const std::string class_str = json::value_to<std::string>(jv);
-    if (class_str == "simple" || class_str.empty())
-        return order_class::SIMPLE;
-    if (class_str == "bracket")
-        return order_class::BRACKET;
-    if (class_str == "oco")
-        return order_class::OCO;
-    if (class_str == "oto")
-        return order_class::OTO;
-    if (class_str == "mleg")
-        return order_class::MLEG;
-    throw std::invalid_argument("Invalid order_class: " + class_str);
+    return enum_value_to_tag_with_fallback<order_class>(jv, order_class::SIMPLE);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const order_type& ot)
 {
-    switch (ot)
-    {
-        case order_type::MARKET:
-            jv = "market";
-            break;
-        case order_type::LIMIT:
-            jv = "limit";
-            break;
-        case order_type::STOP:
-            jv = "stop";
-            break;
-        case order_type::STOP_LIMIT:
-            jv = "stop_limit";
-            break;
-        case order_type::TRAILING_STOP:
-            jv = "trailing_stop";
-            break;
-    }
+    enum_value_from_tag(jv, ot);
 }
 
 order_type tag_invoke(json::value_to_tag<order_type>, const json::value& jv)
 {
-    const std::string type_str = json::value_to<std::string>(jv);
-    if (type_str == "market")
-        return order_type::MARKET;
-    if (type_str == "limit")
-        return order_type::LIMIT;
-    if (type_str == "stop")
-        return order_type::STOP;
-    if (type_str == "stop_limit")
-        return order_type::STOP_LIMIT;
-    if (type_str == "trailing_stop")
-        return order_type::TRAILING_STOP;
-    throw std::invalid_argument("Invalid order_type: " + type_str);
+    return enum_value_to_tag<order_type>(jv);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const time_in_force& tif)
 {
-    switch (tif)
-    {
-        case time_in_force::DAY:
-            jv = "day";
-            break;
-        case time_in_force::GTC:
-            jv = "gtc";
-            break;
-        case time_in_force::OPG:
-            jv = "opg";
-            break;
-        case time_in_force::CLS:
-            jv = "cls";
-            break;
-        case time_in_force::IOC:
-            jv = "ioc";
-            break;
-        case time_in_force::FOK:
-            jv = "fok";
-            break;
-    }
+    enum_value_from_tag(jv, tif);
 }
 
 time_in_force tag_invoke(json::value_to_tag<time_in_force>, const json::value& jv)
 {
-    const std::string tif_str = json::value_to<std::string>(jv);
-    if (tif_str == "day")
-        return time_in_force::DAY;
-    if (tif_str == "gtc")
-        return time_in_force::GTC;
-    if (tif_str == "opg")
-        return time_in_force::OPG;
-    if (tif_str == "cls")
-        return time_in_force::CLS;
-    if (tif_str == "ioc")
-        return time_in_force::IOC;
-    if (tif_str == "fok")
-        return time_in_force::FOK;
-    throw std::invalid_argument("Invalid time_in_force: " + tif_str);
+    return enum_value_to_tag<time_in_force>(jv);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const order_status& os)
 {
-    switch (os)
-    {
-        case order_status::NEW:
-            jv = "new";
-            break;
-        case order_status::PARTIALLY_FILLED:
-            jv = "partially_filled";
-            break;
-        case order_status::FILLED:
-            jv = "filled";
-            break;
-        case order_status::DONE_FOR_DAY:
-            jv = "done_for_day";
-            break;
-        case order_status::CANCELED:
-            jv = "canceled";
-            break;
-        case order_status::EXPIRED:
-            jv = "expired";
-            break;
-        case order_status::REPLACED:
-            jv = "replaced";
-            break;
-        case order_status::PENDING_CANCEL:
-            jv = "pending_cancel";
-            break;
-        case order_status::PENDING_REPLACE:
-            jv = "pending_replace";
-            break;
-        case order_status::ACCEPTED:
-            jv = "accepted";
-            break;
-        case order_status::PENDING_NEW:
-            jv = "pending_new";
-            break;
-        case order_status::ACCEPTED_FOR_BIDDING:
-            jv = "accepted_for_bidding";
-            break;
-        case order_status::STOPPED:
-            jv = "stopped";
-            break;
-        case order_status::REJECTED:
-            jv = "rejected";
-            break;
-        case order_status::SUSPENDED:
-            jv = "suspended";
-            break;
-        case order_status::CALCULATED:
-            jv = "calculated";
-            break;
-    }
+    enum_value_from_tag(jv, os);
 }
 
 order_status tag_invoke(json::value_to_tag<order_status>, const json::value& jv)
 {
-    const std::string status_str = json::value_to<std::string>(jv);
-    if (status_str == "new")
-        return order_status::NEW;
-    if (status_str == "partially_filled")
-        return order_status::PARTIALLY_FILLED;
-    if (status_str == "filled")
-        return order_status::FILLED;
-    if (status_str == "done_for_day")
-        return order_status::DONE_FOR_DAY;
-    if (status_str == "canceled")
-        return order_status::CANCELED;
-    if (status_str == "expired")
-        return order_status::EXPIRED;
-    if (status_str == "replaced")
-        return order_status::REPLACED;
-    if (status_str == "pending_cancel")
-        return order_status::PENDING_CANCEL;
-    if (status_str == "pending_replace")
-        return order_status::PENDING_REPLACE;
-    if (status_str == "accepted")
-        return order_status::ACCEPTED;
-    if (status_str == "pending_new")
-        return order_status::PENDING_NEW;
-    if (status_str == "accepted_for_bidding")
-        return order_status::ACCEPTED_FOR_BIDDING;
-    if (status_str == "stopped")
-        return order_status::STOPPED;
-    if (status_str == "rejected")
-        return order_status::REJECTED;
-    if (status_str == "suspended")
-        return order_status::SUSPENDED;
-    if (status_str == "calculated")
-        return order_status::CALCULATED;
-    throw std::invalid_argument("Invalid order_status: " + status_str);
+    return enum_value_to_tag<order_status>(jv);
 }
 
 void tag_invoke(json::value_from_tag, json::value& jv, const position_intent& pi)
 {
-    switch (pi)
-    {
-        case position_intent::BUY_TO_OPEN:
-            jv = "buy_to_open";
-            break;
-        case position_intent::BUY_TO_CLOSE:
-            jv = "buy_to_close";
-            break;
-        case position_intent::SELL_TO_OPEN:
-            jv = "sell_to_open";
-            break;
-        case position_intent::SELL_TO_CLOSE:
-            jv = "sell_to_close";
-            break;
-    }
+    enum_value_from_tag(jv, pi);
 }
 
 position_intent tag_invoke(json::value_to_tag<position_intent>, const json::value& jv)
 {
-    const std::string intent_str = json::value_to<std::string>(jv);
-    if (intent_str == "buy_to_open")
-        return position_intent::BUY_TO_OPEN;
-    if (intent_str == "buy_to_close")
-        return position_intent::BUY_TO_CLOSE;
-    if (intent_str == "sell_to_open")
-        return position_intent::SELL_TO_OPEN;
-    if (intent_str == "sell_to_close")
-        return position_intent::SELL_TO_CLOSE;
-    throw std::invalid_argument("Invalid position_intent: " + intent_str);
+    return enum_value_to_tag<position_intent>(jv);
 }
 
 order tag_invoke(json::value_to_tag<order>, const json::value& jv)

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -32,15 +32,12 @@ Bar1min::Timestamp parseRFC3339UTCTimestamp(const std::string& timestamp)
         // Format: 2025-05-19T13:30:00Z
         return parse_helper(timestamp, "%Y-%m-%dT%H:%M:%S");
     }
-    else if (timestamp.ends_with("+00:00"))
+    if (timestamp.ends_with("+00:00"))
     {
         // Format: 2025-05-19 13:30:00+00:00
         return parse_helper(timestamp, "%Y-%m-%d %H:%M:%S");
     }
-    else
-    {
-        throw std::invalid_argument{"timestamp must be UTC (end with 'Z' or '+00:00')"};
-    }
+    throw std::invalid_argument{"timestamp must be UTC (end with 'Z' or '+00:00')"};
 
     return {};
 }


### PR DESCRIPTION
## Summary
Refactor the project to use Boost JSON library instead of nlohmann JSON, with improvements to enum serialization and JSON parsing.

## Changes Made
- Replaced nlohmann_json with Boost::json throughout the project
- Added a new `enum_serialization.hpp` with template metaprogramming for enum serialization
- Updated CMake configuration to find and link Boost JSON
- Modified JSON serialization/deserialization methods to use Boost JSON tag_invoke pattern
- Updated GitHub workflow to include Boost JSON library installation
- Improved error handling in JSON parsing
- Refactored JSON conversion methods to use more generic template-based approach